### PR TITLE
add plugin.yaml to be used as oc plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
 # ocdev
 OpenShift Command line for Developers
+
+### How to use ocdev as an oc plugin?
+- make sure that ocdev binary exists in your $PATH
+- copy the [plugin.yaml](./plugin.yaml) file to ~/.kube/plugins/ocdev/
+- use the plugin as `oc plugin dev`

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,0 +1,4 @@
+name: "dev" 
+shortDesc: "ocdev plugin"
+longDesc: "ocdev plugin to use ocdev as a plugin in OpenShift"
+command: "ocdev"


### PR DESCRIPTION
This commit adds the plugin.yaml file to the root of the project
which can be copied to ~/.kube/plugins/ocdev/, thence enabling
ocdev as an oc plugin.