### PR TITLE
remove unused reflect from config pkg

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"os/user"
 	"path/filepath"
-	"reflect"
 
 	"github.com/ghodss/yaml"
 	"github.com/pkg/errors"


### PR DESCRIPTION
this is causing tests to fail

```
$ make test-coverage
./scripts/generate-coverage.sh
?   	github.com/redhat-developer/ocdev	[no test files]
?   	github.com/redhat-developer/ocdev/cmd	[no test files]
?   	github.com/redhat-developer/ocdev/pkg/application	[no test files]
# github.com/redhat-developer/ocdev/pkg/config
/tmp/go-build735719731/github.com/redhat-developer/ocdev/pkg/config/_test/_obj_test/config.go:10:2: imported and not used: "reflect"
FAIL	github.com/redhat-developer/ocdev/pkg/config [build failed]
make: *** [test-coverage] Error 2
```