### PR TITLE
Change deleted to deleting

### DIFF
--- a/cmd/application.go
+++ b/cmd/application.go
@@ -88,7 +88,7 @@ var deleteCmd = &cobra.Command{
 			fmt.Println(err)
 			os.Exit(-1)
 		}
-		fmt.Printf("Deleted application: %v\n", args[0])
+		fmt.Printf("Deleting application: %v\n", args[0])
 	},
 }
 


### PR DESCRIPTION
When doing `oc delete project`, the project is not immediately
deleted, while the command returns a 0 exit code immediately.

For this reason, this commit changes the word "deleted" to
"deleting" so the end user does not get confused when running
`ocdev application list` after `ocdev application delete`