### PR TITLE
Refactor component to fix errors

### DIFF
--- a/cmd/component.go
+++ b/cmd/component.go
@@ -22,6 +22,7 @@ import (
 	"github.com/redhat-developer/ocdev/pkg/component"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+	"github.com/pkg/errors"
 )
 
 var (
@@ -143,13 +144,13 @@ var componentGetCmd = &cobra.Command{
 
 		component, err := component.GetCurrent()
 		if err != nil {
-			fmt.Println(err)
+			fmt.Println(errors.Wrap(err, "unable to get current component"))
 			os.Exit(-1)
 		}
 		if justName {
 			fmt.Print(component)
 		} else {
-			fmt.Printf("The current component is: %v", component)
+			fmt.Printf("The current component is: %v\n", component)
 		}
 	},
 }

--- a/pkg/component/component.go
+++ b/pkg/component/component.go
@@ -112,8 +112,8 @@ func GetCurrent() (string, error) {
 	}
 
 	currentComponent := cfg.GetActiveComponent(currentAppliction)
-	if currentAppliction == "" {
-		return "", errors.Wrap(err, "no component is set as active")
+	if currentComponent == "" {
+		return "", errors.New("no component is set as active")
 	}
 	return currentComponent, nil
 


### PR DESCRIPTION
This commit refactors the `ocdev component` parts to better print,
and also fixes the error when `ocdev component get` will not return
an error when no component is set