### PR TITLE
Fix flaky test due to map to string operation

### DIFF
--- a/pkg/occlient/occlient_test.go
+++ b/pkg/occlient/occlient_test.go
@@ -99,10 +99,11 @@ func TestGetOcBinary(t *testing.T) {
 
 func TestAddLabelsToArgs(t *testing.T) {
 	tests := []struct {
-		name    string
-		argsIn  []string
-		labels  map[string]string
-		argsOut []string
+		name     string
+		argsIn   []string
+		labels   map[string]string
+		argsOut1 []string
+		argsOut2 []string
 	}{
 		{
 			name:   "one label in empty args",
@@ -110,7 +111,7 @@ func TestAddLabelsToArgs(t *testing.T) {
 			labels: map[string]string{
 				"label1": "value1",
 			},
-			argsOut: []string{
+			argsOut1: []string{
 				"--labels", "label1=value1",
 			},
 		},
@@ -122,7 +123,7 @@ func TestAddLabelsToArgs(t *testing.T) {
 			labels: map[string]string{
 				"label1": "value1",
 			},
-			argsOut: []string{
+			argsOut1: []string{
 				"--foo", "bar",
 				"--labels", "label1=value1",
 			},
@@ -136,9 +137,13 @@ func TestAddLabelsToArgs(t *testing.T) {
 				"label1": "value1",
 				"label2": "value2",
 			},
-			argsOut: []string{
+			argsOut1: []string{
 				"--foo", "bar",
 				"--labels", "label1=value1,label2=value2",
+			},
+			argsOut2: []string{
+				"--foo", "bar",
+				"--labels", "label2=value2,label1=value1",
 			},
 		},
 	}
@@ -147,8 +152,8 @@ func TestAddLabelsToArgs(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			argsGot := addLabelsToArgs(tt.labels, tt.argsIn)
 
-			if !reflect.DeepEqual(argsGot, tt.argsOut) {
-				t.Errorf("addLabelsToArgs() \ngot:  %#v \nwant: %#v", argsGot, tt.argsOut)
+			if !reflect.DeepEqual(argsGot, tt.argsOut1) && !reflect.DeepEqual(argsGot, tt.argsOut2) {
+				t.Errorf("addLabelsToArgs() \ngot:  %#v \nwant: %#v or %#v", argsGot, tt.argsOut1, tt.argsOut2)
 			}
 		})
 	}


### PR DESCRIPTION
This is a very poor fix for the flaky test, but I think this should
work for now. The test was "occasionally" failing because the order
in a map is not maintained, so the conversion to string was failing
at times. This commit fixes that.