### PR TITLE
Fix printing of `oc project` output in GetProjects

### DIFF
--- a/pkg/occlient/occlient.go
+++ b/pkg/occlient/occlient.go
@@ -136,7 +136,7 @@ func GetProjects() (string, error) {
 	if err != nil {
 		return "", errors.Wrap(err, "unable to get projects")
 	}
-	return string(output), nil
+	return strings.Join(strings.Split(string(output), "\n")[1:], "\n"), nil
 }
 
 func CreateNewProject(name string) error {


### PR DESCRIPTION
This commit removes the first line being printed at the top of the
output of `oc get project` in GetProjects() function.