### PR TITLE
Implement `ocd component push`

### DIFF
--- a/cmd/component.go
+++ b/cmd/component.go
@@ -155,13 +155,41 @@ var componentGetCmd = &cobra.Command{
 	},
 }
 
+var componentPushCmd = &cobra.Command{
+	Use:   "push",
+	Short: "component push",
+	Long:  "push changes to component",
+	Args:  cobra.MaximumNArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		log.Debug("component push called")
+		var componentName string
+		if len(args) == 0 {
+			var err error
+			log.Debug("No component name passed, assuming current component")
+			componentName, err = component.GetCurrent()
+			if err != nil {
+				fmt.Println(errors.Wrap(err, "unable to get current component"))
+				os.Exit(-1)
+			}
+		}
+		fmt.Printf("pushing changes to component: %v\n", componentName)
+		if _, err := component.Push(componentName, &componentDir); err != nil {
+			fmt.Printf("failed to push component: %v", componentName)
+			os.Exit(-1)
+		}
+		fmt.Printf("changes successfully pushed to component: %v\n", componentName)
+	},
+}
+
 func init() {
 	componentCreateCmd.Flags().StringVar(&componentBinary, "binary", "", "binary artifact")
 	componentCreateCmd.Flags().StringVar(&componentGit, "git", "", "git source")
 	componentCreateCmd.Flags().StringVar(&componentDir, "dir", "", "local directory as source")
 
 	componentGetCmd.Flags().BoolVarP(&justName, "short", "", false, "If true, display only the component name")
+	componentPushCmd.Flags().StringVar(&componentDir, "dir", "", "specify directory to push changes from")
 
+	componentCmd.AddCommand(componentPushCmd)
 	componentCmd.AddCommand(componentCreateCmd)
 	componentCmd.AddCommand(componentDeleteCmd)
 	componentCmd.AddCommand(componentGetCmd)

--- a/pkg/component/component.go
+++ b/pkg/component/component.go
@@ -57,7 +57,7 @@ func CreateFromDir(name string, ctype, dir string) (string, error) {
 	fmt.Println(output)
 	fmt.Println("please wait, building application...")
 
-	output, err = occlient.StartBuildFromDir(name, dir)
+	output, err = occlient.StartBuild(name, &dir)
 	if err != nil {
 		return "", err
 	}
@@ -117,4 +117,12 @@ func GetCurrent() (string, error) {
 	}
 	return currentComponent, nil
 
+}
+
+func Push(name string, dir *string) (string, error) {
+	output, err := occlient.StartBuild(name, dir)
+	if err != nil {
+		return "", errors.Wrap(err, "unable to start build")
+	}
+	return output, nil
 }

--- a/pkg/occlient/occlient.go
+++ b/pkg/occlient/occlient.go
@@ -210,12 +210,14 @@ func NewAppS2IEmpty(name string, builderImage string, labels map[string]string) 
 	return string(output[:]), nil
 }
 
-func StartBuildFromDir(name string, dir string) (string, error) {
+func StartBuild(name string, dir *string) (string, error) {
 	args := []string{
 		"start-build",
 		name,
-		"--from-dir", dir,
 		"--follow",
+	}
+	if dir != nil {
+		args = append(args, "--from-dir", *dir)
 	}
 
 	// TODO: build progress is not shown


### PR DESCRIPTION
This commit implements `ocd component push` which lets the user
push the local or remote changes to the running application in
the OpenShift cluster.