### PR TITLE
check if binary has correct version when doing release

### DIFF
--- a/scripts/prepare-release.sh
+++ b/scripts/prepare-release.sh
@@ -5,6 +5,19 @@ RELEASE_DIR="./dist/release/"
 
 mkdir -p $RELEASE_DIR
 
+# if this is run on travis make sure that binary was build with corrent version
+if [[ -n $TRAVIS_TAG ]]; then
+    echo "Checking if ocdev version was set to the same version as current tag"
+    # use sed to get only semver part
+    bin_version=$(${BIN_DIR}/darwin-amd64/ocdev version | sed 's/ .*//g')
+    if [ "$TRAVIS_TAG" == "v${bin_version}" ]; then
+        echo "OK: ocdev version output is matching current tag"
+    else
+        echo "ERR: TRAVIS_TAG ($TRAVIS_TAG) is not matching 'ocdev version' (v${bin_version})"
+        exit 1
+    fi
+fi
+
 for arch in `ls -1 $BIN_DIR/`;do
     suffix=""
     if [[ $arch == windows-* ]]; then


### PR DESCRIPTION
when `make prepare-release` is run on travis check that `ocdev version` matches git tag version


I've forgot to change version when doing first release ;-)