### PR TITLE
build  rpm and deb packages and upload them to repositories

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,9 @@ jobs:
         - make goget-tools
       script: skip
       before_deploy:
+        - make cross
         - make prepare-release
+        - make packages
         - ./scripts/generate-bintray-json.sh
       deploy:
         - provider: bintray

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,10 @@ sudo: false
 
 language: go
 
+env:
+  global:
+    - secure: "SSGPlBUXMb2F3ycFEvRKHoftYy0UkIprwgtfOKXU/Uc359Qct+IrF/b8GuTd64tedXtnQE4z4fxqT8wdYRdNwUysmOvRyzlNTRhs1gocx5iL5El8+7F4we7wElh6ckt2Z5AVI5g0JOwYeQNURFhgDumN14K8XsOu7a2LzRBVFRn55z79xgTL+JnTI89JIWjz1QCr8Z054CMaK0MHJRLkgPnbnx1Skra3Wt16g29wRZLqLWoU8lyrLy9Ao/yHw/AJMCNie8ah7nNiOEdgPTcr/onZ/v+eVyaTvzE9UrmdeqpUpASypAAUnmZ9Q6QsU31dVxwbfPB0r8TzrqinCOYMnHbU/3fIz49Q+yv7RyifYsTlnx7+J79LmCvs7X+iKkmOprWdBRwUUxzDhwgIGnmBlYf0nKj9H2U3XFCYDnbRSI9ZugGBprs3t09w15gwq/wLM6DhY87zNhM4Vfb34ZXVBCEhtUXKUVbVthiPOWlHtbs0YympG/QCV+27tVIszgek8FFt6/fJeEh/APNadK9fuU01ozB01aXj0xMl3PlvoWWeQXDnyttHEWRaiVpbPKGoV5a7LPCVpWk5EOX8YNgHEUnjKwfzVBUriXAd+8zp0sx6TRdt1ts7x04NP1yFF1SCXXBpz/geOsfa2bBQyJx6y7CODcmW7fbcJLxmwdGlm6E="
+    - secure: "Tr9KxWvfQS6BSF1qUqz1Q41le5k/c+L37Aq8wTPQcmXVu8nLv5T1QMarx64KfZ2qaQBRV+M6DwnJQM7HU/cWX9AKpdoAO2INqANfoFLh8XTR5ncHjaNTzi9aS7owxa+9t0yfKowq7s4dp96nqmwchYFtUxpzKo0TMOcQ1l1AGEu5liniXb9VOKgG8UAZsLgD6b2a80nn6NP1JehGGxcWsow0EzxalnJ8Cv78YTLmqGNowYh5UmkhjkxqE4TskQafRd2qtYMPvxnC2CFd8G3qMlbBzCxM02lGKwbr/Vi41hcSyD3uuyaKVHr/g5qLcp/HNyrUGTREL1UvWkWjlL6ovuh6uHYlnpVwQkX5fzUH7z2hlr9HjQ3Tu6Sbh1CX5QBR5PUkvoOfdx0BHTmTTw2xkvUDHarqZT1OkMuUplCY/VMnJaqa5ko126r8CyKYqRoT4HQuqa6szVawGiB211VCQXJRVyLYtKUGO6mmnMUoi5H676/sv6c9py8bieMoyEyrI87lS0AhQ6QLnTjNbEO5xt6vFi7rEgcctD5nuEBwb/X2bmM2OdZFYXrIbXaZfq7fRKyzCQthfceCmySExOGI9ndCE/mS68X6NNFBVsVwb7zt0zSY6oGlf0/N2CR5sf8gwKYG1scr5Jyqmuifvqv433zepA0Sxj6WqC3ixlssNd8="
 jobs:
   include:
     # YAML alias, for settings shared across the tests
@@ -39,16 +43,16 @@ jobs:
         - make packages
         - ./scripts/generate-bintray-json.sh
       deploy:
+        # upload binaries to bintray
         - provider: bintray
           repo: ocdev/ocdev
           file: ./.bintray.json
-          user:
-            secure: L3AL5N1UKoztNJA2methw6ChS0JmO8lkRmuHjNHS7ICWUFhWulzPubk6zApuGUxIeIpzOaY25p7gWdj7yHNQ3q622KwFKwM+zHPA0eOgl2IL2SEH6d0CJvOKze7LP+B6A+weht4T+WbSbD/kQS7WcZAT0oc1KbxYBfEtD11yLd9G11AlRC1TNO9uKvhgR941qFTNm+nwQrVQ74T11ILXv2nRh3i5IjzC+tfr39CyDVD61/p2p9J3KUf5oV4m9iYC9J2NTBakpmefwxZQM7Gkb/qubmojBWFyP2rGGuilTpvPnou6Qs9Gn2kx6+Xr6I3NPVMsJqsWFl1aiTnzRUP23hXNSlKKmjAvOY8X8+TNeh6kTDE0TT580k02Xgwd8F5FdDfAQsCW5Nb9MjK0t9wSrnZA72yXI1b/hGB0XllVfG58Ep49o720af0IN2v44rclPqxCIGXZp5bCKSujeiAGpmSuxrDpl3+4Iiba8aoNdKgtRbryAWxu1Roy1pj57EUJ7cgkWOACAcm7Jb2BZe9yivkFrrI3K2EeH4eWzFv/jjHmoVInYacO7DL0DurI4B1GEs3K+nmEzODWHt8yYhTuNv2LWxvrMqe1I4KMvnzKoowv2nc+pxWBEQ27Fsa+t/ZmQmOm+RH+uVSD7YY2UneFCBBOc0YuMADi+BzXB30aXc0=
-          key:
-            secure: HVlwXufcjEVXCKeEwZyHe0y8IP7ins0B3t1+hLLiHPA5RVVm3FH0o60+GDAzP4vWsJ5MCdey/Y6pJ5F6UNH9TByt0D+pBubwZEd+OGKJMO0VCdVx6Ca9pBMfsLbP5v74Z8nws5c6aBRE6WICgiQfosXUPNzZNL0czhQNFGwcMhcKCM9WfOSEY0d5KhxwMS2x4ORwCovJw06qRMSQarIvCXDDPUzopbN44zxxtlMjsFtsFEqPfFxuY9xYBUZDs9AkSwh5og9rXDLi97zQs+ojeF9tf7IN0FFEkvXReuLqQL6+t2hfEV+ykMRSDmwM+CXbqrIPRO3USTEGLVfUVbuRJYHCUCvATcnt5wy16xlYOhB9bwt1SpcSx9INZH6BHQyrKoT8gSRONUBkOKMpYEDINveuhHN7ucmLTKYXThU9aqxWHa4+p0xXqEhuJXNq84vjU43wGnZRaWguSKJWDZRQ2AvQmGnskKTJOpXQTMEfMxBltMnp/zcxsw05wT0aRpeUDZpdrNjB/bzgzZL5tjuNU0jX5TrGVR05m+LKHs0ac3XQ1+c8+Se5N2hbVzskAH9csWl6dcodmSUqyoJqqUNQU97UVgAAjyGDlXjzLk6MQJDP9Pk5b6LIh7oNk1vZ7R2YdrEU2u1fCQHZx/QcLNXSWRKtTj75DtRVKjKrJ86oDPs=
+          user: $BINTRAY_USER
+          key: $BINTRAY_KEY
           skip_cleanup: true
           on:
             on: master
+        # upload gziped binaries to github release page
         - provider: releases
           api_key:
             secure: GGP7Kk+ZjhwwOTOgY4/TufeZ82Xh6SQDJkUlig6qzOCd01Rh80waWz5X0MzNgf2UotjeiVpgFbhZ3DOeUDwkRxa+/MmmiX+gxgeS+tb5YnhnFzH0Q/13DYFF+RQQrr8jmFs7d4dm56L3U3gW4qFwyHgn9Fy5Aqsd4R4RmObV4sVtxh1Z4g4px1hJNiaKFd7T9ChFPS/fuSz75ThrSQjG4rJFWW5Sb6BPmEOkwMCGAc+b24oEZngq8HMDknuKLU1UTSOef9T9yo65M4uVVMI1RkmbmazObkd6216L7XlIvZrLhINIy3Jl7RCtT2JLgKEmHQ9582WIenRIm4PerlMn6sDHmfb+oYW2JMXhgYEOBzXk0K/RmiRGc8tCpSfEpB5qe6z28+l8SvirX9plBqZytG0EwXUVEt7qwSOlLtfrT/4tJCVpmmXDoJR/TtDrHe2HqsBTBQJpYDrOemqmEAcDDMFVG+yZq4iO+Z1jTdEqUMXUE+0UYl22//Y3+xGzvS+JEIzwU/VI2Sg+zDlTvkogQBl7IQqNl/ttXgLcRl0V/E2PpJR/gJUlEyYImKI3Gh4pV5cY7IRuT17fytp249KyK/q3mkE85/yKWPZc/fGVgqbqL7pdHTuVg/woDv46kK1VFC2lDB9Ll5yWrMGI6U/kxO8bzPa88PE0Z4i4yMoRRLo=
@@ -60,3 +64,11 @@ jobs:
           on:
             tags: true
             repo: redhat-developer/ocdev
+        # upload packages to bintray repositories
+        - provider: script
+          skip_cleanup: true
+          script:
+            - make upload-packages
+          on:
+            tags: true
+            branch: master

--- a/Makefile
+++ b/Makefile
@@ -67,3 +67,10 @@ test:
 .PHONY: packages
 packages:
 	./scripts/create-packages.sh
+	./scripts/create-packages.
+
+# upload packages greated by 'make packages' to bintray repositories
+# run 'make cross' and 'make packages' before this!
+.PHONY: upload-packages
+upload-packages:
+	./scripts/upload-packages.sh

--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,9 @@ cross:
 generate-cli-docs:
 	go run scripts/generate-cli-documentation.go
 
+# create gzipped binaries in ./dist/release/
+# for uploading to GitHub release page
+# run make cross before this!
 .PHONY: prepare-release
 prepare-release: cross
 	./scripts/prepare-release.sh
@@ -58,3 +61,9 @@ prepare-release: cross
 .PHONY: test
 test:
 	go test -race $(PKGS)
+
+# create deb and rpm packages using fpm in ./dist/pkgs/
+# run make cross before this!
+.PHONY: packages
+packages:
+	./scripts/create-packages.sh

--- a/scripts/create-packages.sh
+++ b/scripts/create-packages.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+# fpm is required installed (https://github.com/jordansissel/fpm)
+
+BIN_DIR="./dist/bin/"
+PKG_DIR="./dist/pkgs/"
+
+mkdir -p $PKG_DIR
+
+# package version, use current date by default (if build from master)
+PKG_VERSION=$(date "+%Y%m%d%H%M%S")
+
+# if this is run on travis make sure that binary was build with corrent version
+if [[ -n $TRAVIS_TAG ]]; then
+    echo "Checking if ocdev version was set to the same version as current tag"
+    # use sed to get only semver part
+    bin_version=$(${BIN_DIR}/linux-amd64/ocdev version | sed 's/ .*//g')
+    if [ "$TRAVIS_TAG" == "v${bin_version}" ]; then
+        echo "OK: ocdev version output is matching current tag"
+    else
+        echo "ERR: TRAVIS_TAG ($TRAVIS_TAG) is not matching 'ocdev version' (v${bin_version})"
+        exit 1
+    fi
+    # this is build from tag, that means it is proper relase, use version for PKG_VERSION
+    PKG_VERSION="${bin_version}"
+fi
+
+# create packages using fpm
+fpm -h  >/dev/null 2>&1 || { 
+    echo "ERROR: fpm (https://github.com/jordansissel/fpm) is not installed. Can't create linux packages"
+    exit 1
+}
+
+TMP_DIR=$(mktemp -d)
+mkdir -p $TMP_DIR/usr/local/bin/
+cp $BIN_DIR/linux-amd64/ocdev $TMP_DIR/usr/local/bin/
+
+echo "creating DEB package"
+fpm \
+  --input-type dir --output-type deb \
+  --chdir $TMP_DIR \
+  --name ocdev --version $PKG_VERSION \
+  --architecture amd64 \
+  --maintainer "Tomas Kral <tkral@redhat.com>" \
+  --package $PKG_DIR
+
+echo "creating RPM package"
+fpm \
+  --input-type dir --output-type rpm \
+  --chdir $TMP_DIR \
+  --name ocdev --version $PKG_VERSION \
+  --architecture x86_64 --rpm-os linux \
+  --maintainer "Tomas Kral <tkral@redhat.com>" \
+  --package $PKG_DIR

--- a/scripts/prepare-release.sh
+++ b/scripts/prepare-release.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+# this script assumes that runs on linux
+
 BIN_DIR="./dist/bin/"
 RELEASE_DIR="./dist/release/"
 
@@ -18,10 +20,15 @@ if [[ -n $TRAVIS_TAG ]]; then
     fi
 fi
 
+# gziped binaries
 for arch in `ls -1 $BIN_DIR/`;do
     suffix=""
     if [[ $arch == windows-* ]]; then
         suffix=".exe"
     fi
-    gzip --keep --to-stdout $BIN_DIR/$arch/ocdev$suffix > $RELEASE_DIR/ocdev-$arch$suffix.gz
+    source_file=$BIN_DIR/$arch/ocdev$suffix
+    target_file=$RELEASE_DIR/ocdev-$arch$suffix.gz
+
+    echo "gzipping binary $source_file as $target_file"
+    gzip --keep --to-stdout $source_file > $target_file
 done

--- a/scripts/upload-packages.sh
+++ b/scripts/upload-packages.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+# upload linux packages to bintray repositories
+# required $BINTRAY_USER and $BINTRAY_KEY
+
+PKG_DIR="./dist/pkgs/"
+
+
+if [[ -z "${BINTRAY_USER}" ]] || [[ -z "${BINTRAY_KEY}" ]]  ; then
+    echo "Required variables \$BINTRAY_USER and \$BINTRAY_KEY"
+    exit 1
+fi
+
+
+#  for deb
+for pkg in `ls -1 $PKG_DIR/*.deb`; do 
+    filename=$(basename $pkg)
+    # get version from filename
+    version=$(expr "$filename" : '.*_\([^_]*\)_.*')
+
+    repo="ocdev-deb-dev"
+    # if version is semver format upload to releases
+    if [[ $version =~ [0-9]+\.[0-9]+\.[0-9]+ ]] ; then 
+        repo="ocdev-deb-releases"
+    fi
+    
+    echo "Uploading DEB package $pkg version $version to Bintray $repo"
+
+    curl -T $pkg -u $BINTRAY_USER:$BINTRAY_KEY "https://api.bintray.com/content/ocdev/${repo}/ocdev/${version}/${filename};deb_distribution=stretch;deb_component=main;deb_architecture=amd64;publish=1"
+    echo ""
+    echo ""
+done
+
+#  for rpm
+for pkg in `ls -1 $PKG_DIR/*.rpm`; do 
+    filename=$(basename $pkg)
+    # get version from filename
+    version=$(expr "$filename" : '.*-\(.*-[0-9]*\)\.x86_64.*')
+
+    repo="ocdev-rpm-dev"
+    # if version is semver format upload to releases
+    if [[ $version =~ [0-9]+\.[0-9]+\.[0-9]+ ]] ; then 
+        repo="ocdev-rpm-releases"
+    fi
+    
+    echo "Uploading RPM package $pkg version $version to Bintray $repo"
+    curl -T $pkg -u $BINTRAY_USER:$BINTRAY_KEY "https://api.bintray.com/content/ocdev/${repo}/ocdev/${version}/${filename};publish=1"
+    echo ""
+    echo ""
+done


### PR DESCRIPTION
It creates binary packages, so they can't be used in any of the official distribution's repositories.
But they can be used in our repository to make it easier for users to install ocdev.

there are two types of packages
 - build from master: version number is timestamp
     (YearMonthDateHourMinuteSecond) those are uploaded to
     ocdev-rpm-dev and ocdev-deb-dev repositories
 - build from tag: those are released version and they have normal
     semver version. They are uploaded to ocdev-rpm-releses and
     ocdev-deb-releases repositories 


Packages are build and uploaded automatically by Travis.

PR with documentation on how to install it from repos will follow.

