### PR TITLE
Allow multiple applications in one OpenShift project

### DIFF
--- a/cmd/application.go
+++ b/cmd/application.go
@@ -1,17 +1,3 @@
-// Copyright © 2018 NAME HERE <EMAIL ADDRESS>
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
 package cmd
 
 import (
@@ -22,8 +8,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const defaultApplication = "app"
-
 // applicationCmd represents the app command
 var applicationCmd = &cobra.Command{
 	Use:     "application",
@@ -31,18 +15,19 @@ var applicationCmd = &cobra.Command{
 	Aliases: []string{"app"},
 }
 
-var createCmd = &cobra.Command{
+var applicationCreateCmd = &cobra.Command{
 	Use:   "create",
 	Short: "create an application",
-	Args:  cobra.MaximumNArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
-		var name string
-		// Set default application name if not set
-		if len(args) == 0 {
-			name = defaultApplication
-		} else {
-			name = args[0]
+	Args: func(cmd *cobra.Command, args []string) error {
+		if len(args) != 1 {
+			return fmt.Errorf("Please provide name for the new application")
 		}
+		return nil
+	},
+	Run: func(cmd *cobra.Command, args []string) {
+		// Args validation makes sure that there is exactly one argument
+		name := args[0]
+
 		fmt.Printf("Creating application: %v\n", name)
 		if err := application.Create(name); err != nil {
 			fmt.Println(err)
@@ -97,12 +82,19 @@ var listCmd = &cobra.Command{
 	Short: "lists all the applications",
 	Args:  cobra.ExactArgs(0),
 	Run: func(cmd *cobra.Command, args []string) {
-		app, err := application.List()
+		apps, err := application.List()
 		if err != nil {
 			fmt.Println(err)
 			os.Exit(-1)
 		}
-		fmt.Print(app)
+		fmt.Printf("ACTIVE   NAME\n")
+		for _, app := range apps {
+			activeMark := " "
+			if app.Active {
+				activeMark = "*"
+			}
+			fmt.Printf("  %s      %s\n", activeMark, app.Name)
+		}
 	},
 }
 
@@ -112,6 +104,6 @@ func init() {
 	applicationCmd.AddCommand(listCmd)
 	applicationCmd.AddCommand(deleteCmd)
 	applicationCmd.AddCommand(getCmd)
-	applicationCmd.AddCommand(createCmd)
+	applicationCmd.AddCommand(applicationCreateCmd)
 	rootCmd.AddCommand(applicationCmd)
 }

--- a/pkg/application/application.go
+++ b/pkg/application/application.go
@@ -58,6 +58,8 @@ func Create(name string) error {
 }
 
 // List all application in current project
+// shows also empty applications (empty applications are those that are just
+//  mentioned in config but don't have any object associated with it on cluster)
 func List() ([]ApplicationInfo, error) {
 	// TODO: use project abstaction
 	project, err := occlient.GetCurrentProjectName()
@@ -85,6 +87,23 @@ func List() ([]ApplicationInfo, error) {
 		applications = append(applications, ApplicationInfo{
 			Name:    name,
 			Active:  active,
+			Project: project,
+		})
+	}
+
+	cfg, err := config.New()
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to create new application")
+	}
+
+	// Application can be created but empty.
+	// In that case it won't show in the list above, as there are no objects with application
+	// label in the cluster. Only place where this application is mentioned is local config.
+	activeApp := cfg.GetActiveApplication(project)
+	if activeApp != "" {
+		applications = append(applications, ApplicationInfo{
+			Name:    activeApp,
+			Active:  true,
 			Project: project,
 		})
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -16,7 +16,19 @@ const (
 )
 
 type Config struct {
-	// key - project name, value - component name
+	// remember active applications and components per project
+	// when project or applications is switched we can go back to last active app/component
+
+	// Currently active application
+	// key - project name
+	// value - application name
+	ActiveApplications map[string]string `json:"activeApplications"`
+
+	// TODO: situation when there is multiple applications with the same name in different projects is not handled currently
+
+	// Currently active component
+	// key - application name
+	// value - component name
 	ActiveComponents map[string]string `json:"activeComponents"`
 }
 
@@ -94,11 +106,11 @@ func (c *ConfigInfo) writeToFile() error {
 	return nil
 }
 
-func (c *ConfigInfo) SetActiveComponent(component string, project string) error {
+func (c *ConfigInfo) SetActiveComponent(component string, application string) error {
 	if c.ActiveComponents == nil {
 		c.ActiveComponents = make(map[string]string)
 	}
-	c.ActiveComponents[project] = component
+	c.ActiveComponents[application] = component
 	err := c.writeToFile()
 	if err != nil {
 		return errors.Wrap(err, "unable to set current component")
@@ -106,11 +118,32 @@ func (c *ConfigInfo) SetActiveComponent(component string, project string) error 
 	return nil
 }
 
-// GetCurrentComponet if no component is set as current returns empty string
-func (c *ConfigInfo) GetActiveComponent(project string) string {
+// GetActiveComponent if no component is set as current returns empty string
+func (c *ConfigInfo) GetActiveComponent(application string) string {
 	if c.ActiveComponents != nil {
-		return c.ActiveComponents[project]
+		return c.ActiveComponents[application]
 	}
 	return ""
+}
 
+// GetActiveApplication get currently active application for given project
+// if no application is active return empty string
+func (c *ConfigInfo) GetActiveApplication(project string) string {
+	if c.ActiveApplications != nil {
+		return c.ActiveApplications[project]
+	}
+	return ""
+}
+
+// SetActiveApplication set application as active for given project
+func (c *ConfigInfo) SetActiveApplication(application string, project string) error {
+	if c.ActiveApplications == nil {
+		c.ActiveApplications = make(map[string]string)
+	}
+	c.ActiveApplications[project] = application
+	err := c.writeToFile()
+	if err != nil {
+		return errors.Wrap(err, "unable to set current component")
+	}
+	return nil
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -56,7 +56,6 @@ func TestNew(t *testing.T) {
 }
 
 func TestSetActiveComponent(t *testing.T) {
-
 	tempConfigFile, err := ioutil.TempFile("", "ocdevconfig")
 	if err != nil {
 		t.Fatal(err)
@@ -68,13 +67,13 @@ func TestSetActiveComponent(t *testing.T) {
 		name           string
 		existingConfig Config
 		setComponent   string
-		project        string
+		application    string
 	}{
 		{
 			name:           "activeComponents nil",
 			existingConfig: Config{},
 			setComponent:   "foo",
-			project:        "bar",
+			application:    "bar",
 		},
 		{
 			name: "activeComponents empty",
@@ -82,7 +81,7 @@ func TestSetActiveComponent(t *testing.T) {
 				ActiveComponents: make(map[string]string),
 			},
 			setComponent: "foo",
-			project:      "bar",
+			application:  "bar",
 		},
 		{
 			name: "activeComponents existing",
@@ -92,7 +91,7 @@ func TestSetActiveComponent(t *testing.T) {
 				},
 			},
 			setComponent: "foo",
-			project:      "bar",
+			application:  "bar",
 		},
 		{
 			name: "overwrite existing active component",
@@ -102,7 +101,7 @@ func TestSetActiveComponent(t *testing.T) {
 				},
 			},
 			setComponent: "foo",
-			project:      "bar",
+			application:  "bar",
 		},
 	}
 
@@ -112,19 +111,19 @@ func TestSetActiveComponent(t *testing.T) {
 			if err != nil {
 				t.Error(err)
 			}
-			err = cfg.SetActiveComponent(tt.setComponent, tt.project)
+			err = cfg.SetActiveComponent(tt.setComponent, tt.application)
 			if err != nil {
 				t.Error(err)
 			}
 
 			found := false
-			for aproj, acomp := range cfg.ActiveComponents {
-				if aproj == tt.project && acomp == tt.setComponent {
+			for app, acomp := range cfg.ActiveComponents {
+				if app == tt.application && acomp == tt.setComponent {
 					found = true
 				}
 			}
 			if !found {
-				t.Errorf("component %s/%s was not set as current", tt.project, tt.setComponent)
+				t.Errorf("component %s/%s was not set as current", tt.application, tt.setComponent)
 			}
 
 		})
@@ -132,7 +131,6 @@ func TestSetActiveComponent(t *testing.T) {
 }
 
 func TestGetActiveComponent(t *testing.T) {
-
 	tempConfigFile, err := ioutil.TempFile("", "ocdevconfig")
 	if err != nil {
 		t.Fatal(err)
@@ -141,24 +139,24 @@ func TestGetActiveComponent(t *testing.T) {
 	os.Setenv(configEnvName, tempConfigFile.Name())
 
 	tests := []struct {
-		name            string
-		existingConfig  Config
-		activeProject   string
-		activeComponent string
+		name              string
+		existingConfig    Config
+		activeApplication string
+		activeComponent   string
 	}{
 		{
-			name:            "no component active",
-			existingConfig:  Config{},
-			activeProject:   "test",
-			activeComponent: "",
+			name:              "no component active",
+			existingConfig:    Config{},
+			activeApplication: "test",
+			activeComponent:   "",
 		},
 		{
 			name: "activeComponents empty",
 			existingConfig: Config{
 				ActiveComponents: make(map[string]string),
 			},
-			activeProject:   "test",
-			activeComponent: "",
+			activeApplication: "test",
+			activeComponent:   "",
 		},
 		{
 			name: "no activeComponet record for given project",
@@ -167,8 +165,8 @@ func TestGetActiveComponent(t *testing.T) {
 					"a": "b",
 				},
 			},
-			activeProject:   "test",
-			activeComponent: "",
+			activeApplication: "test",
+			activeComponent:   "",
 		},
 		{
 			name: "activeComponents for one project",
@@ -177,8 +175,8 @@ func TestGetActiveComponent(t *testing.T) {
 					"a": "b",
 				},
 			},
-			activeProject:   "a",
-			activeComponent: "b",
+			activeApplication: "a",
+			activeComponent:   "b",
 		},
 		{
 			name: "multiple projects",
@@ -188,8 +186,8 @@ func TestGetActiveComponent(t *testing.T) {
 					"a":   "b",
 				},
 			},
-			activeProject:   "a",
-			activeComponent: "b",
+			activeApplication: "a",
+			activeComponent:   "b",
 		},
 	}
 
@@ -198,10 +196,162 @@ func TestGetActiveComponent(t *testing.T) {
 			cfg := ConfigInfo{
 				Config: tt.existingConfig,
 			}
-			output := cfg.GetActiveComponent(tt.activeProject)
+			output := cfg.GetActiveComponent(tt.activeApplication)
 
 			if output != tt.activeComponent {
 				t.Errorf("active component doesn't match expected \ngot: %s \nexpected: %s\n", output, tt.activeComponent)
+			}
+
+		})
+	}
+}
+
+func TestSetActiveApplication(t *testing.T) {
+	tempConfigFile, err := ioutil.TempFile("", "ocdevconfig")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tempConfigFile.Close()
+	os.Setenv(configEnvName, tempConfigFile.Name())
+
+	tests := []struct {
+		name           string
+		existingConfig Config
+		setApplication string
+		project        string
+	}{
+		{
+			name:           "activeApplication nil",
+			existingConfig: Config{},
+			setApplication: "foo",
+			project:        "bar",
+		},
+		{
+			name: "activeApplication empty",
+			existingConfig: Config{
+				ActiveApplications: make(map[string]string),
+			},
+			setApplication: "foo",
+			project:        "bar",
+		},
+		{
+			name: "activeApplication existing",
+			existingConfig: Config{
+				ActiveApplications: map[string]string{
+					"a": "b",
+				},
+			},
+			setApplication: "foo",
+			project:        "bar",
+		},
+		{
+			name: "overwrite existing active Application",
+			existingConfig: Config{
+				ActiveApplications: map[string]string{
+					"foo": "foo",
+				},
+			},
+			setApplication: "foo",
+			project:        "bar",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg, err := New()
+			if err != nil {
+				t.Error(err)
+			}
+			err = cfg.SetActiveApplication(tt.setApplication, tt.project)
+			if err != nil {
+				t.Error(err)
+			}
+
+			found := false
+			for proj, app := range cfg.ActiveApplications {
+				if proj == tt.project && app == tt.setApplication {
+					found = true
+				}
+			}
+			if !found {
+				t.Errorf("application %s/%s was not set as current", tt.project, tt.setApplication)
+			}
+
+		})
+	}
+}
+
+func TestGetActiveApplication(t *testing.T) {
+
+	tempConfigFile, err := ioutil.TempFile("", "ocdevconfig")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tempConfigFile.Close()
+	os.Setenv(configEnvName, tempConfigFile.Name())
+
+	tests := []struct {
+		name              string
+		existingConfig    Config
+		activeProject     string
+		activeApplication string
+	}{
+		{
+			name:              "no application active",
+			existingConfig:    Config{},
+			activeProject:     "test",
+			activeApplication: "",
+		},
+		{
+			name: "activeApplications empty",
+			existingConfig: Config{
+				ActiveApplications: make(map[string]string),
+			},
+			activeProject:     "test",
+			activeApplication: "",
+		},
+		{
+			name: "no activeApplication record for given project",
+			existingConfig: Config{
+				ActiveApplications: map[string]string{
+					"a": "b",
+				},
+			},
+			activeProject:     "test",
+			activeApplication: "",
+		},
+		{
+			name: "activeApplication for one project",
+			existingConfig: Config{
+				ActiveApplications: map[string]string{
+					"a": "b",
+				},
+			},
+			activeProject:     "a",
+			activeApplication: "b",
+		},
+		{
+			name: "multiple application",
+			existingConfig: Config{
+				ActiveApplications: map[string]string{
+					"foo": "foo",
+					"a":   "b",
+				},
+			},
+			activeProject:     "a",
+			activeApplication: "b",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := ConfigInfo{
+				Config: tt.existingConfig,
+			}
+			output := cfg.GetActiveApplication(tt.activeProject)
+
+			if output != tt.activeApplication {
+				t.Errorf("active application doesn't match expected \ngot: %s \nexpected: %s\n", output, tt.activeApplication)
 			}
 
 		})

--- a/pkg/occlient/occlient_test.go
+++ b/pkg/occlient/occlient_test.go
@@ -2,7 +2,6 @@ package occlient
 
 import (
 	"io/ioutil"
-	"log"
 	"os"
 	"reflect"
 	"testing"
@@ -14,11 +13,11 @@ func TestGetOcBinary(t *testing.T) {
 	// test shouldn't have external dependency, so we are faking oc binary with empty tmpfile
 	tmpfile, err := ioutil.TempFile("", "fake-oc")
 	if err != nil {
-		log.Fatal(err)
+		t.Fatal(err)
 	}
 	tmpfile1, err := ioutil.TempFile("", "fake-oc")
 	if err != nil {
-		log.Fatal(err)
+		t.Fatal(err)
 	}
 	defer os.Remove(tmpfile.Name())
 	defer os.Remove(tmpfile1.Name())


### PR DESCRIPTION
Applications are now grouped using labeles.

`app.kubernetes.io/name` is used for application grouping.
`app.kubernetes.io/component-name` is used for component grouping

It is also possible to add additional labels to applications.
Currently, there is  `app` label for OpenShift console.

fixes #85 #83 



