### PR TITLE
travis - separate master and releases upload

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -74,4 +74,11 @@ jobs:
             - make upload-packages
           on:
             tags: true
+        - provider: script
+          skip_cleanup: true
+          script:
+            - make upload-packages
+          on:
             branch: master
+
+


### PR DESCRIPTION
you can't run one deploy job for tags and master