### PR TITLE
Add installation script to ocdev

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,22 @@ jobs:
         # submit coverage.txt to codecov.io 
         - bash <(curl -s https://codecov.io/bash)
 
+    # test installation script on linux
+    - stage: test
+      services:
+        - docker
+      install:
+        - true
+      script:
+        ./scripts/test-install.sh
+    # test installation script on macOS
+    - state: test
+      os: osx
+      install:
+        - true
+      script:
+        ./scripts/install.sh
+
     - stage: deploy
       go_import_path:  github.com/redhat-developer/ocdev
       go: 1.9
@@ -81,5 +97,3 @@ jobs:
             - make upload-packages
           on:
             branch: master
-
-

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Please follow [OpenShift documentation](https://docs.openshift.org/latest/cli_re
 ## Installation
 - Run the following command to install the latest ocdev release on Linux or macOS -
 
-`curl -L https://github.com/redhat-developer/ocdev/raw/master/scripts/install.sh | sh`
+`curl -L https://github.com/redhat-developer/ocdev/raw/master/scripts/install.sh | bash`
 
 You can download latest master builds from [Bintray](https://dl.bintray.com/ocdev/ocdev/latest/) or 
 builds for released versions from [GitHub releases page](https://github.com/redhat-developer/ocdev/releases).

--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ Please follow [OpenShift documentation](https://docs.openshift.org/latest/cli_re
 
 
 ## Installation
+- Run the following command to install the latest ocdev release on Linux or macOS -
+
+`curl -L https://github.com/redhat-developer/ocdev/raw/master/scripts/install.sh | sh`
+
 You can download latest master builds from [Bintray](https://dl.bintray.com/ocdev/ocdev/latest/) or 
 builds for released versions from [GitHub releases page](https://github.com/redhat-developer/ocdev/releases).
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -7,7 +7,9 @@
 Making artifacts for new release is automated. 
 When new git tag is created, Travis-ci deploy job automatically builds binaries and uploads it to GitHub release page.
 
-1. Create PR with updated version in `cmd/version.go`
+1. Create PR with updated version in following files:
+    - `cmd/version.go`
+    - `scripts/install.sh`
 2. When PR is merged create and push new git tag for version.
     ```
     git tag v0.0.1

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,227 @@
+#!/bin/bash
+set -e
+
+# The version of ocdev to install. Possible values - "master" and "latest"
+OCDEV_VERSION="latest"
+
+GITHUB_RELEASES_URL="https://github.com/redhat-developer/ocdev/releases/download/v0.0.1"
+BINTRAY_URL="https://dl.bintray.com/ocdev/ocdev/latest"
+
+INSTALLATION_PATH="/usr/local/bin/"
+PRIVILEGED_EXECUTION="sh -c"
+
+DEBIAN_GPG_PUBLIC_KEY="https://bintray.com/user/downloadSubjectPublicKey?username=bintray"
+DEBIAN_MASTER_REPOSITORY="https://dl.bintray.com/ocdev/ocdev-deb-dev"
+DEBIAN_LATEST_REPOSITORY="https://dl.bintray.com/ocdev/ocdev-deb-releases"
+
+RPM_MASTER_YUM_REPO="https://bintray.com/ocdev/ocdev-rpm-dev/rpm"
+RPM_LATEST_YUM_REPO="https://bintray.com/ocdev/ocdev-rpm-releases/rpm"
+
+SUPPORTED_PLATFORMS="
+darwin-amd64
+linux-amd64
+linux-arm
+"
+
+echo_stderr ()
+{
+    echo "$@" >&2
+}
+
+command_exists() {
+	command -v "$@" > /dev/null 2>&1
+}
+
+check_platform() {
+    kernel="$(uname -s)"
+    if [ "$(uname -m)" = "x86_64" ]; then
+        arch="amd64"
+    fi
+
+    platform_type="${kernel,,}-$arch"
+
+    if ! echo "# $SUPPORTED_PLATFORMS" | grep "$platform_type" > /dev/null; then
+        echo_stderr "
+# The installer has detected your platform to be $platform_type, which is
+# currently not supported by this installer script.
+
+# Please visit the following URL for detailed installation steps:
+# https://github.com/redhat-developer/ocdev/#installation
+
+        "
+        exit 1
+    fi
+    echo "$platform_type"
+}
+
+get_distribution() {
+	lsb_dist=""
+	if [ -r /etc/os-release ]; then
+		lsb_dist="$(. /etc/os-release && echo "$ID")"
+	fi
+	echo "$lsb_dist"
+}
+
+set_privileged_execution() {
+	if [ "$(id -u)" != "0" ]; then
+        if command_exists sudo; then
+            echo "# Installer will run privileged commands with sudo"
+            PRIVILEGED_EXECUTION='sudo -E sh -c'
+        elif command_exists su ; then
+            echo "# Installer will run privileged commands with \"su -c\""
+            PRIVILEGED_EXECUTION='su -c'
+        else
+    	    echo_stderr "# 
+This installer needs to run as root. The current user is not root, and we could not find "sudo" or "su" installed on the system. Please run again with root privileges, or install "sudo" or "su" packages.
+"
+        fi
+    else
+        echo "# Installer is being run as root"
+	fi
+}
+
+invalid_ocdev_version_error() {
+    echo_stderr "# Invalid value of ocdev version provided, provide master or latest."
+    exit 1
+}
+
+install_ocdev() {
+    echo "# Starting ocdev installation..."
+    echo "# Detecting distribution..."
+
+    platform="$(check_platform)"
+    echo "# Detected platform: $platform"
+
+    if command_exists ocdev; then
+        echo_stderr "# 
+ocdev version \"$(ocdev version)\" is already installed on your system, running this installer script might case issues with your current installation. If you want to install ocdev using this script, please remove the current installation of ocdev from you system.
+Aborting now!
+"
+        exit 1
+    fi
+
+    # macOS specific steps
+    if [ "$platform" = "darwin-amd64" ]; then
+        if ! command_exists brew; then
+            echo_stderr "# brew command does not exist. Please install and run the installer again."
+        fi
+
+        echo "# Enabling kadel/ocdev... "
+        brew tap kadel/ocdev
+
+        echo "Installing ocdev..."
+        case "$OCDEV_VERSION" in
+        master)
+            brew install kadel/ocdev/ocdev -- HEAD
+            ;;
+        latest)
+            brew install kadel/ocdev/ocdev
+        esac
+
+        return 0
+    fi
+
+    set_privileged_execution
+
+    distribution=$(get_distribution)
+  	echo "# Detected distribution: $distribution"
+  	echo "# Installing ocdev version: $OCDEV_VERSION"
+
+    case "$distribution" in
+
+    ubuntu|debian)
+        echo "# Installing pre-requisites..."
+        $PRIVILEGED_EXECUTION "apt-get update"
+        $PRIVILEGED_EXECUTION "apt-get install -y gnupg apt-transport-https"
+
+        echo "# "Adding GPG public key...
+        $PRIVILEGED_EXECUTION "curl -L \"$DEBIAN_GPG_PUBLIC_KEY\" |  apt-key add -"
+
+        echo "# Adding repository to /etc/apt/sources.list"
+        case "$OCDEV_VERSION" in
+        master)
+            $PRIVILEGED_EXECUTION "echo \"deb $DEBIAN_MASTER_REPOSITORY stretch main\" |  tee -a /etc/apt/sources.list"
+            ;;
+        latest)
+            $PRIVILEGED_EXECUTION "echo \"deb $DEBIAN_LATEST_REPOSITORY stretch main\" | tee -a /etc/apt/sources.list"
+            ;;
+        *)
+            invalid_ocdev_version_error
+        esac
+
+        $PRIVILEGED_EXECUTION "apt-get update"
+        $PRIVILEGED_EXECUTION "apt-get install -y ocdev"
+        ;;
+
+    centos|fedora)
+        package_manager=""
+        case "$distribution" in
+        fedora)
+            package_manager="dnf"
+            ;;
+        centos)
+            package_manager="yum"
+            ;;
+        esac
+
+        echo "# Adding ocdev repo under /etc/yum.repos.d/"
+        case "$OCDEV_VERSION" in
+
+        master)
+            $PRIVILEGED_EXECUTION "curl -L $RPM_MASTER_YUM_REPO -o /etc/yum.repos.d/bintray-ocdev-ocdev-rpm-dev.repo"
+            ;;
+        latest)
+            $PRIVILEGED_EXECUTION "curl -L $RPM_LATEST_YUM_REPO -o /etc/yum.repos.d/bintray-ocdev-ocdev-rpm-releases.repo"
+            ;;
+        *)
+            invalid_ocdev_version_error
+        esac
+
+        $PRIVILEGED_EXECUTION "$package_manager install -y ocdev"
+        ;;
+
+    *)
+        echo "# Could not identify distribution, proceeding with a binary install..."
+
+        BINARY_URL=""
+        case "$OCDEV_VERSION" in
+        master)
+            BINARY_URL="$BINTRAY_URL/$platform/ocdev"
+            echo "# Downloading ocdev from $BINARY_URL"
+            curl -Lo ocdev "$BINARY_URL"
+            ;;
+        latest)
+            BINARY_URL="$GITHUB_RELEASES_URL/ocdev-$platform.gz"
+            echo "# Downloading ocdev from $BINARY_URL"
+            curl -Lo ocdev.gz "$BINARY_URL"
+            echo "# Extracting ocdev.gz"
+            gunzip -d ocdev.gz
+            ;;
+        *)
+            invalid_ocdev_version_error
+        esac
+
+        echo "# Setting execute permissions on ocdev"
+        chmod +x ocdev
+        echo "# Moving ocdev binary to $INSTALLATION_PATH"
+        $PRIVILEGED_EXECUTION "mv ocdev $INSTALLATION_PATH"
+        echo "# ocdev has been successfully installed on your machine"
+        ;;
+    esac
+}
+
+verify_ocdev() {
+    if command_exists ocdev; then
+        echo "
+# Verification complete!
+# ocdev version \"$(ocdev version)\" has been installed at $(type -P ocdev)
+"
+    else
+        echo_stderr "
+# Something is wrong with ocdev installation, please run the installaer script again. If the issue persists, please create an issue at https://github.com/redhat-developer/ocdev/issues"
+        exit 1
+    fi
+}
+
+install_ocdev
+verify_ocdev

--- a/scripts/test-install.sh
+++ b/scripts/test-install.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# this script test install.sh in different distributions using docker.
+
+# docker images where install script will be tested in
+DOCKER_IMAGES="ubuntu:latest debian:latest fedora:latest base/archlinux:latest"
+
+# save tests that failed to this variable
+FAILED_INSTALL=""
+
+for image in $DOCKER_IMAGES; do
+    echo "******************************************************"
+    echo "*** Testing install.sh in $image"
+    echo "******************************************************"
+    
+    docker run -it --rm -v `pwd`:/opt/ocdev $image /opt/ocdev/scripts/install.sh
+    if [ $? -eq 0 ]; then
+        echo "******************************************************"
+        echo "**** PASSED for $image"
+        echo "******************************************************"
+    else
+        echo "******************************************************"
+        echo "**** FAILED for $image"
+        echo "******************************************************"
+        FAILED_INSTALL="$FAILED_INSTALL $image"
+    fi
+    echo ""
+done
+
+
+if [ -n "$FAILED_INSTALL" ]; then
+    echo "TEST FAILED!!"
+    echo "Instalation script failed in following images:"
+    echo "$FAILED_INSTALL"
+else
+    echo "ALL TESTS SUCCEEDED"
+fi


### PR DESCRIPTION
This commit adds an installation shell script to install ocdev
on Linux machines. The script currently downloads only the latest
ocdev release from GitHub.

related to https://github.com/redhat-developer/ocdev/issues/74