### PR TITLE
Fixed macOS text

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Please follow [OpenShift documentation](https://docs.openshift.org/latest/cli_re
 You can download latest master builds from [Bintray](https://dl.bintray.com/ocdev/ocdev/latest/) or 
 builds for released versions from [GitHub releases page](https://github.com/redhat-developer/ocdev/releases).
 
-### MacOS
+### macOS
 1. First you need enable `kadel/ocdev` Homebrew Tap:
     ```sh
     brew tap kadel/ocdev


### PR DESCRIPTION
From 2016, Apple is branding its OS as macOS. 
See https://en.wikipedia.org/wiki/MacOS.