### PR TITLE
Allow setting active application and component

### DIFF
--- a/cmd/application.go
+++ b/cmd/application.go
@@ -102,6 +102,27 @@ var applicationListCmd = &cobra.Command{
 	},
 }
 
+var applicationSetCmd = &cobra.Command{
+	Use:   "set",
+	Short: "Set application as active.",
+	Args: func(cmd *cobra.Command, args []string) error {
+		if len(args) < 1 {
+			return fmt.Errorf("Please provide application name")
+		}
+		if len(args) > 1 {
+			return fmt.Errorf("Only one argument (application name) is allowed")
+		}
+		return nil
+	}, Run: func(cmd *cobra.Command, args []string) {
+		err := application.SetCurrent(args[0])
+		if err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+		fmt.Printf("Switched to application: %v\n", args[0])
+	},
+}
+
 func init() {
 	applicationGetCmd.Flags().BoolVarP(&applicationShortFlag, "short", "q", false, "If true, display only the application name")
 
@@ -109,6 +130,7 @@ func init() {
 	applicationCmd.AddCommand(applicationDeleteCmd)
 	applicationCmd.AddCommand(applicationGetCmd)
 	applicationCmd.AddCommand(applicationCreateCmd)
+	applicationCmd.AddCommand(applicationSetCmd)
 
 	rootCmd.AddCommand(applicationCmd)
 }

--- a/cmd/component.go
+++ b/cmd/component.go
@@ -174,6 +174,27 @@ var componentPushCmd = &cobra.Command{
 	},
 }
 
+var componentSetCmd = &cobra.Command{
+	Use:   "set",
+	Short: "Set component as active.",
+	Args: func(cmd *cobra.Command, args []string) error {
+		if len(args) < 1 {
+			return fmt.Errorf("Please provide component name")
+		}
+		if len(args) > 1 {
+			return fmt.Errorf("Only one argument (component name) is allowed")
+		}
+		return nil
+	}, Run: func(cmd *cobra.Command, args []string) {
+		err := component.SetCurrent(args[0])
+		if err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+		fmt.Printf("Switched to component: %v\n", args[0])
+	},
+}
+
 func init() {
 	componentCreateCmd.Flags().StringVar(&componentBinary, "binary", "", "binary artifact")
 	componentCreateCmd.Flags().StringVar(&componentGit, "git", "", "git source")
@@ -187,6 +208,7 @@ func init() {
 	componentCmd.AddCommand(componentDeleteCmd)
 	componentCmd.AddCommand(componentGetCmd)
 	componentCmd.AddCommand(componentCreateCmd)
+	componentCmd.AddCommand(componentSetCmd)
 
 	rootCmd.AddCommand(componentCmd)
 }

--- a/pkg/application/application.go
+++ b/pkg/application/application.go
@@ -1,6 +1,8 @@
 package application
 
 import (
+	"fmt"
+
 	"github.com/pkg/errors"
 	"github.com/redhat-developer/ocdev/pkg/config"
 	"github.com/redhat-developer/ocdev/pkg/occlient"
@@ -167,6 +169,24 @@ func SetCurrent(name string) error {
 	project, err := occlient.GetCurrentProjectName()
 	if err != nil {
 		return errors.Wrap(err, "unable to get active application")
+	}
+
+	apps, err := List()
+	if err != nil {
+		return errors.Wrap(err, "unable to get active application")
+
+	}
+	// check if application exists
+	found := false
+	for _, app := range apps {
+
+		if app.Name == name {
+			found = true
+			break
+		}
+	}
+	if !found {
+		return fmt.Errorf("application %s doesn't exist", name)
 	}
 
 	cfg, err := config.New()


### PR DESCRIPTION
fixes #68 

Currently implemented as
```
ocdev component set <name>
ocdev application set <name>
```

In use case document this is used without subcommand like this:
```
ocdev application <name>
ocdev component <name>
```
But the problem with not using subcommand is that it puts restrictions on application names. For example, `list` can't be used as application name, because there is `ocdev application list` subcommand.
```
▶ ./ocdev application create list
Creating application: list
Switched to application: list

▶ ./ocdev application list
ACTIVE   NAME
         f
         app
         myapp
  *      list
```



I've chosen `set` as it is short and descriptive. I was also considering `activate` and `use`.

