### PR TITLE
Get latest release info in a non-blocking manner

### DIFF
--- a/pkg/notify/notify.go
+++ b/pkg/notify/notify.go
@@ -2,10 +2,11 @@ package notify
 
 import (
 	"context"
+	"strings"
+
 	"github.com/blang/semver"
 	"github.com/google/go-github/github"
 	"github.com/pkg/errors"
-	"strings"
 )
 
 const (
@@ -19,16 +20,19 @@ const (
 
 // getLatestReleaseTag polls ocdev's upstream GitHub repository to get the
 // tag of the latest release
-func getLatestReleaseTag() (string, error) {
+func getLatestReleaseTag() (tag string, err error) {
 	client := github.NewClient(nil)
 	release, response, err := client.Repositories.GetLatestRelease(context.Background(), ghorg, ghrepo)
-	defer func() {
-		if err = response.Body.Close(); err != nil {
-			err = errors.Wrap(err, "closing response body failed")
-		}
-	}()
-
-	return *release.TagName, nil
+	if response != nil {
+		defer func() {
+			if err = response.Body.Close(); err != nil {
+				err = errors.Wrap(err, "closing response body failed")
+			}
+		}()
+		tag = *release.TagName
+		return
+	}
+	return
 }
 
 // CheckLatestReleaseTag returns the latest release tag if a newer latest


### PR DESCRIPTION
Prior to this commit, the latest release information was fetched
from GitHub in a blocking manner, which means that even for a very
quick command like `ocdev version`, the tool would wait for a few
seconds before outputting the version, because the execution would
be blocked on waiting for the response from GitHub APIs.

This commit changes that and makes the request to GitHub
concurrent and non-blocking. This means that if the request has
not completed but the program execution has ended, then the tool
will exit gracefully without waiting for the request to complete.

However, if the program execution took longer than the request and
the response has been received by the goroutine before the program
execution is over, then, if applicable, the information is
printed.

Fixes #122