### PR TITLE
Cleanup cobra names.

### DIFF
--- a/cmd/application.go
+++ b/cmd/application.go
@@ -8,6 +8,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var (
+	applicationShortFlag bool
+)
+
 // applicationCmd represents the app command
 var applicationCmd = &cobra.Command{
 	Use:     "application",
@@ -40,8 +44,7 @@ var applicationCreateCmd = &cobra.Command{
 	},
 }
 
-var isQuiet bool
-var getCmd = &cobra.Command{
+var applicationGetCmd = &cobra.Command{
 	Use:   "get",
 	Short: "get the active application",
 	Args:  cobra.ExactArgs(0),
@@ -51,7 +54,7 @@ var getCmd = &cobra.Command{
 			fmt.Println(err)
 			os.Exit(-1)
 		}
-		if isQuiet {
+		if applicationShortFlag {
 			fmt.Print(app)
 		} else {
 			fmt.Printf("The current application is: %v\n", app)
@@ -59,7 +62,7 @@ var getCmd = &cobra.Command{
 	},
 }
 
-var deleteCmd = &cobra.Command{
+var applicationDeleteCmd = &cobra.Command{
 	Use:   "delete",
 	Short: "delete the given application",
 	Args: func(cmd *cobra.Command, args []string) error {
@@ -78,7 +81,7 @@ var deleteCmd = &cobra.Command{
 	},
 }
 
-var listCmd = &cobra.Command{
+var applicationListCmd = &cobra.Command{
 	Use:   "list",
 	Short: "lists all the applications",
 	Args:  cobra.ExactArgs(0),
@@ -100,11 +103,12 @@ var listCmd = &cobra.Command{
 }
 
 func init() {
-	getCmd.Flags().BoolVarP(&isQuiet, "short", "q", false, "If true, display only the application name")
+	applicationGetCmd.Flags().BoolVarP(&applicationShortFlag, "short", "q", false, "If true, display only the application name")
 
-	applicationCmd.AddCommand(listCmd)
-	applicationCmd.AddCommand(deleteCmd)
-	applicationCmd.AddCommand(getCmd)
+	applicationCmd.AddCommand(applicationListCmd)
+	applicationCmd.AddCommand(applicationDeleteCmd)
+	applicationCmd.AddCommand(applicationGetCmd)
 	applicationCmd.AddCommand(applicationCreateCmd)
+
 	rootCmd.AddCommand(applicationCmd)
 }

--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -23,7 +23,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var completion = &cobra.Command{
+var completionCmd = &cobra.Command{
 	Use:   "completion SHELL",
 	Short: "Output shell completion code",
 	Long: `Generates shell completion code.
@@ -74,7 +74,7 @@ func Generate(cmd *cobra.Command, args []string) error {
 }
 
 func init() {
-	rootCmd.AddCommand(completion)
+	rootCmd.AddCommand(completionCmd)
 }
 
 /*

--- a/cmd/component.go
+++ b/cmd/component.go
@@ -26,10 +26,10 @@ import (
 )
 
 var (
-	componentBinary string
-	componentGit    string
-	componentDir    string
-	justName        bool
+	componentBinary    string
+	componentGit       string
+	componentDir       string
+	componentShortFlag bool
 )
 
 // componentCmd represents the component command
@@ -147,7 +147,7 @@ var componentGetCmd = &cobra.Command{
 			fmt.Println(errors.Wrap(err, "unable to get current component"))
 			os.Exit(-1)
 		}
-		if justName {
+		if componentShortFlag {
 			fmt.Print(component)
 		} else {
 			fmt.Printf("The current component is: %v\n", component)
@@ -191,11 +191,11 @@ func init() {
 	componentCreateCmd.Flags().StringVar(&componentGit, "git", "", "git source")
 	componentCreateCmd.Flags().StringVar(&componentDir, "dir", "", "local directory as source")
 
-	componentGetCmd.Flags().BoolVarP(&justName, "short", "", false, "If true, display only the component name")
+	componentGetCmd.Flags().BoolVarP(&componentShortFlag, "short", "q", false, "If true, display only the component name")
+
 	componentPushCmd.Flags().StringVar(&componentDir, "dir", "", "specify directory to push changes from")
 
 	componentCmd.AddCommand(componentPushCmd)
-	componentCmd.AddCommand(componentCreateCmd)
 	componentCmd.AddCommand(componentDeleteCmd)
 	componentCmd.AddCommand(componentGetCmd)
 


### PR DESCRIPTION
Use the same naming pattern for all cobra commands variables.
The patter is camel-cased `<root command name><subcommand name>Cmd`. Example `applicationListCmd`.
