### PR TITLE
Add back 'ocde component create' command

### DIFF
--- a/cmd/component.go
+++ b/cmd/component.go
@@ -184,6 +184,7 @@ func init() {
 	componentCmd.AddCommand(componentPushCmd)
 	componentCmd.AddCommand(componentDeleteCmd)
 	componentCmd.AddCommand(componentGetCmd)
+	componentCmd.AddCommand(componentCreateCmd)
 
 	rootCmd.AddCommand(componentCmd)
 }


### PR DESCRIPTION
It was removed by mistake when refactoring cobra variables :-(
#132 