### PR TITLE
update commands structure to match it to what is in use cases

### DIFF
--- a/cmd/application.go
+++ b/cmd/application.go
@@ -17,6 +17,8 @@ var applicationCmd = &cobra.Command{
 	Use:     "application",
 	Short:   "application",
 	Aliases: []string{"app"},
+	// 'ocdev application' is the same as 'ocdev application get'
+	Run: applicationGetCmd.Run,
 }
 
 var applicationCreateCmd = &cobra.Command{
@@ -125,6 +127,8 @@ var applicationSetCmd = &cobra.Command{
 
 func init() {
 	applicationGetCmd.Flags().BoolVarP(&applicationShortFlag, "short", "q", false, "If true, display only the application name")
+	// add flags from 'get' to application command
+	applicationCmd.Flags().AddFlagSet(applicationGetCmd.Flags())
 
 	applicationCmd.AddCommand(applicationListCmd)
 	applicationCmd.AddCommand(applicationDeleteCmd)

--- a/cmd/application.go
+++ b/cmd/application.go
@@ -38,7 +38,7 @@ var applicationCreateCmd = &cobra.Command{
 		fmt.Printf("Creating application: %v\n", name)
 		if err := application.Create(name); err != nil {
 			fmt.Println(err)
-			os.Exit(-1)
+			os.Exit(1)
 		}
 		fmt.Printf("Switched to application: %v\n", name)
 	},
@@ -52,7 +52,7 @@ var applicationGetCmd = &cobra.Command{
 		app, err := application.GetCurrent()
 		if err != nil {
 			fmt.Println(err)
-			os.Exit(-1)
+			os.Exit(1)
 		}
 		if applicationShortFlag {
 			fmt.Print(app)
@@ -75,7 +75,7 @@ var applicationDeleteCmd = &cobra.Command{
 		err := application.Delete(args[0])
 		if err != nil {
 			fmt.Println(err)
-			os.Exit(-1)
+			os.Exit(1)
 		}
 		fmt.Printf("Deleted application: %s\n", args[0])
 	},
@@ -89,7 +89,7 @@ var applicationListCmd = &cobra.Command{
 		apps, err := application.List()
 		if err != nil {
 			fmt.Println(err)
-			os.Exit(-1)
+			os.Exit(1)
 		}
 		fmt.Printf("ACTIVE   NAME\n")
 		for _, app := range apps {

--- a/cmd/component.go
+++ b/cmd/component.go
@@ -141,39 +141,6 @@ var componentGetCmd = &cobra.Command{
 	},
 }
 
-var componentPushCmd = &cobra.Command{
-	Use:   "push",
-	Short: "component push",
-	Long:  "push changes to component",
-	Args:  cobra.MaximumNArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
-		log.Debug("component push called")
-		var componentName string
-		if len(args) == 0 {
-			var err error
-			log.Debug("No component name passed, assuming current component")
-			componentName, err = component.GetCurrent()
-			if err != nil {
-				fmt.Println(errors.Wrap(err, "unable to get current component"))
-				os.Exit(-1)
-			}
-		} else {
-			componentName = args[0]
-		}
-		fmt.Printf("pushing changes to component: %v\n", componentName)
-
-		if len(componentDir) == 0 {
-			componentDir = "."
-		}
-
-		if _, err := component.Push(componentName, componentDir); err != nil {
-			fmt.Printf("failed to push component: %v", componentName)
-			os.Exit(-1)
-		}
-		fmt.Printf("changes successfully pushed to component: %v\n", componentName)
-	},
-}
-
 var componentSetCmd = &cobra.Command{
 	Use:   "set",
 	Short: "Set component as active.",
@@ -202,9 +169,6 @@ func init() {
 
 	componentGetCmd.Flags().BoolVarP(&componentShortFlag, "short", "q", false, "If true, display only the component name")
 
-	componentPushCmd.Flags().StringVar(&componentDir, "dir", "", "specify directory to push changes from")
-
-	componentCmd.AddCommand(componentPushCmd)
 	componentCmd.AddCommand(componentDeleteCmd)
 	componentCmd.AddCommand(componentGetCmd)
 	componentCmd.AddCommand(componentCreateCmd)

--- a/cmd/component.go
+++ b/cmd/component.go
@@ -131,7 +131,7 @@ var componentGetCmd = &cobra.Command{
 		component, err := component.GetCurrent()
 		if err != nil {
 			fmt.Println(errors.Wrap(err, "unable to get current component"))
-			os.Exit(-1)
+			os.Exit(1)
 		}
 		if componentShortFlag {
 			fmt.Print(component)

--- a/cmd/component.go
+++ b/cmd/component.go
@@ -23,6 +23,8 @@ var componentCmd = &cobra.Command{
 	Use:   "component",
 	Short: "components of application",
 	Long:  "components of application",
+	// 'ocdev component' is the same as 'ocdev component get'
+	Run: componentGetCmd.Run,
 }
 
 var componentCreateCmd = &cobra.Command{
@@ -168,6 +170,8 @@ func init() {
 	componentCreateCmd.Flags().StringVar(&componentDir, "dir", "", "local directory as source")
 
 	componentGetCmd.Flags().BoolVarP(&componentShortFlag, "short", "q", false, "If true, display only the component name")
+	// add flags from 'get' to component command
+	componentCmd.Flags().AddFlagSet(applicationGetCmd.Flags())
 
 	componentCmd.AddCommand(componentDeleteCmd)
 	componentCmd.AddCommand(componentGetCmd)

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -1,0 +1,6 @@
+package cmd
+
+// 'ocdev crate' is just an alias for 'ocdev component create'
+func init() {
+	rootCmd.AddCommand(componentCreateCmd)
+}

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -1,0 +1,57 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/redhat-developer/ocdev/pkg/component"
+
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+var pushCmd = &cobra.Command{
+	Use:   "push [component name]",
+	Short: "Push source code to component",
+	Long:  `Push source code to component.`,
+	Example: `  # Push source code in current directory to current component
+  ocdev push
+
+  # Push source code in ~/home/mycode to component called my-component
+  ocdev push my-component --dir ~/home/mycode
+	`,
+	Args: cobra.MaximumNArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		log.Debug("component push called")
+		var componentName string
+		if len(args) == 0 {
+			var err error
+			log.Debug("No component name passed, assuming current component")
+			componentName, err = component.GetCurrent()
+			if err != nil {
+				fmt.Println(errors.Wrap(err, "unable to get current component"))
+				os.Exit(1)
+			}
+		} else {
+			componentName = args[0]
+		}
+		fmt.Printf("pushing changes to component: %v\n", componentName)
+
+		if len(componentDir) == 0 {
+			componentDir = "."
+		}
+
+		if _, err := component.Push(componentName, componentDir); err != nil {
+			fmt.Printf("failed to push component: %v", componentName)
+			os.Exit(1)
+		}
+		fmt.Printf("changes successfully pushed to component: %v\n", componentName)
+	},
+}
+
+func init() {
+	pushCmd.Flags().StringVar(&componentDir, "dir", "", "specify directory to push changes from")
+
+	rootCmd.AddCommand(pushCmd)
+}

--- a/cmd/storage.go
+++ b/cmd/storage.go
@@ -2,11 +2,12 @@ package cmd
 
 import (
 	"fmt"
+	"os"
+
 	"github.com/redhat-developer/ocdev/pkg/component"
 	"github.com/redhat-developer/ocdev/pkg/occlient"
 	"github.com/redhat-developer/ocdev/pkg/storage"
 	"github.com/spf13/cobra"
-	"os"
 )
 
 var (
@@ -20,7 +21,7 @@ func getComponent() string {
 		c, err := component.GetCurrent()
 		if err != nil {
 			fmt.Printf("Could not get current component: %v\n", err)
-			os.Exit(-1)
+			os.Exit(1)
 		}
 		return c
 	}
@@ -47,7 +48,7 @@ var storageAddCmd = &cobra.Command{
 		})
 		if err != nil {
 			fmt.Printf("Failed to add storage: %v\n", err)
-			os.Exit(-1)
+			os.Exit(1)
 		}
 		fmt.Printf("Added storage %v to %v\n", args[0], cmpnt)
 	},
@@ -71,7 +72,7 @@ var storageRemoveCmd = &cobra.Command{
 		})
 		if err != nil {
 			fmt.Printf("Failed to remove storage: %v\n", err)
-			os.Exit(-1)
+			os.Exit(1)
 		}
 		if len(args) == 0 {
 			fmt.Printf("Removed all storage from %v\n", cmpnt)
@@ -92,7 +93,7 @@ var storageListCmd = &cobra.Command{
 		})
 		if err != nil {
 			fmt.Printf("Failed to list storage: %v\n", err)
-			os.Exit(-1)
+			os.Exit(1)
 		}
 		fmt.Println(output)
 	},


### PR DESCRIPTION
- change `component push` to `push`
  Push is now a root level command as specified in use cases.
   fixes #86
- change all `os.Exit(-1)` to `os.Exit(1)` 
  (exit code should be between 0-255)
-  `ocdev app` and `ocdev component` shows current app/component
    `ocdev application` is the same as `ocdev application get`
    `ocdev component` is the same as `ocdev component get`
- add `ocdev create` as an alias for `ocdev component create`
