### PR TITLE
fix release automation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,9 +57,8 @@ jobs:
         - sudo apt-get install -y rpm
         # Ideally following commands should be in before_deploy section
         # but travis-ci runs before_deploy for every provider. We don't want that.
-        - make cross
-        - ./scripts/generate-bintray-json.sh
         - make prepare-release
+        - ./scripts/generate-bintray-json.sh
         - make packages
       script: skip
       deploy:

--- a/scripts/create-packages.sh
+++ b/scripts/create-packages.sh
@@ -22,7 +22,7 @@ if [[ -n $TRAVIS_TAG ]]; then
         exit 1
     fi
     # this is build from tag, that means it is proper relase, use version for PKG_VERSION
-    PKG_VERSION="${bin_version}"
+    PKG_VERSION=$(echo ${bin_version} | sed "s/^v\(.*\)$/\1/")
 fi
 
 # create packages using fpm


### PR DESCRIPTION
because of change in `ocdev version` output generated packages had an invalid version.