### PR TITLE
Add more verbosity to test runs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ prepare-release: cross
 
 .PHONY: test
 test:
-	go test -race $(PKGS)
+	go test -v -race $(PKGS)
 
 # create deb and rpm packages using fpm in ./dist/pkgs/
 # run make cross before this!

--- a/scripts/generate-coverage.sh
+++ b/scripts/generate-coverage.sh
@@ -7,7 +7,7 @@ set -e
 echo "" > coverage.txt
 
 for d in $(go list ./... | grep -v vendor); do
-    go test -race -coverprofile=profile.out -covermode=atomic $d
+    go test -v -race -coverprofile=profile.out -covermode=atomic $d
     if [ -f profile.out ]; then
         cat profile.out >> coverage.txt
         rm profile.out


### PR DESCRIPTION
This commit adds `-v` to the `go test` commands so we get more
verbose output in runs in tests, which will be easier to debug in
case of failures.