### PR TITLE
fix application list and get

### DIFF
--- a/cmd/application.go
+++ b/cmd/application.go
@@ -58,9 +58,13 @@ var applicationGetCmd = &cobra.Command{
 		}
 		if applicationShortFlag {
 			fmt.Print(app)
-		} else {
-			fmt.Printf("The current application is: %v\n", app)
+			return
 		}
+		if app == "" {
+			fmt.Printf("There's no active application.\nYou can create one by running 'ocdev application create <name>'.")
+			return
+		}
+		fmt.Printf("The current application is: %v\n", app)
 	},
 }
 

--- a/cmd/component.go
+++ b/cmd/component.go
@@ -138,6 +138,10 @@ var componentGetCmd = &cobra.Command{
 		if componentShortFlag {
 			fmt.Print(component)
 		} else {
+			if component == "" {
+				fmt.Printf("No component is set as current\n")
+				return
+			}
 			fmt.Printf("The current component is: %v\n", component)
 		}
 	},

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -112,12 +112,13 @@ func (c *ConfigInfo) writeToFile() error {
 	return nil
 }
 
-// SetActiveComponent sets active component of currently active application
-func (c *ConfigInfo) SetActiveComponent(component string, project string) error {
+// SetActiveComponent sets active component for given project and application.
+// application must exist
+func (c *ConfigInfo) SetActiveComponent(component string, application string, project string) error {
 	found := false
 	if c.ActiveApplications != nil {
 		for i, app := range c.ActiveApplications {
-			if app.Project == project && app.Active == true {
+			if app.Project == project && app.Name == application {
 				c.ActiveApplications[i].ActiveComponent = component
 				found = true
 				break
@@ -126,12 +127,12 @@ func (c *ConfigInfo) SetActiveComponent(component string, project string) error 
 	}
 
 	if !found {
-		return fmt.Errorf("no active application in %s project, unable to set active componet", project)
+		return fmt.Errorf("unable to set %s component as active, application %s in %s project doesn't exists", component, application, project)
 	}
 
 	err := c.writeToFile()
 	if err != nil {
-		return errors.Wrap(err, "unable to set current component")
+		return errors.Wrapf(err, "unable to set %s as active component", component)
 	}
 	return nil
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -68,6 +68,7 @@ func TestSetActiveComponent(t *testing.T) {
 		existingConfig Config
 		component      string
 		project        string
+		application    string
 		wantErr        bool
 		result         []ApplicationInfo
 	}{
@@ -76,6 +77,7 @@ func TestSetActiveComponent(t *testing.T) {
 			existingConfig: Config{},
 			component:      "foo",
 			project:        "bar",
+			application:    "app",
 			wantErr:        true,
 			result:         nil,
 		},
@@ -90,9 +92,10 @@ func TestSetActiveComponent(t *testing.T) {
 					},
 				},
 			},
-			component: "foo",
-			project:   "test",
-			wantErr:   false,
+			component:   "foo",
+			project:     "test",
+			application: "a",
+			wantErr:     false,
 			result: []ApplicationInfo{
 				ApplicationInfo{
 					Name:            "a",
@@ -103,7 +106,7 @@ func TestSetActiveComponent(t *testing.T) {
 			},
 		},
 		{
-			name: "no project active",
+			name: "project doesn't exists",
 			existingConfig: Config{
 				ActiveApplications: []ApplicationInfo{
 					ApplicationInfo{
@@ -114,10 +117,29 @@ func TestSetActiveComponent(t *testing.T) {
 					},
 				},
 			},
-			component: "foo",
-			project:   "test",
-			wantErr:   true,
-			result:    nil,
+			component:   "foo",
+			project:     "nonexisting",
+			application: "a",
+			wantErr:     true,
+			result:      nil,
+		},
+		{
+			name: "application doesn't exists",
+			existingConfig: Config{
+				ActiveApplications: []ApplicationInfo{
+					ApplicationInfo{
+						Name:            "a",
+						Active:          false,
+						Project:         "test",
+						ActiveComponent: "b",
+					},
+				},
+			},
+			component:   "foo",
+			project:     "test",
+			application: "nonexisting",
+			wantErr:     true,
+			result:      nil,
 		},
 		{
 			name: "overwrite existing active component (apps with same name in different projects)",
@@ -137,9 +159,10 @@ func TestSetActiveComponent(t *testing.T) {
 					},
 				},
 			},
-			component: "new",
-			project:   "test",
-			wantErr:   false,
+			component:   "new",
+			project:     "test",
+			application: "a",
+			wantErr:     false,
 			result: []ApplicationInfo{
 				ApplicationInfo{
 					Name:            "a",
@@ -173,9 +196,10 @@ func TestSetActiveComponent(t *testing.T) {
 					},
 				},
 			},
-			component: "new",
-			project:   "test",
-			wantErr:   false,
+			component:   "new",
+			project:     "test",
+			application: "a",
+			wantErr:     false,
 			result: []ApplicationInfo{
 				ApplicationInfo{
 					Name:            "a",
@@ -201,7 +225,7 @@ func TestSetActiveComponent(t *testing.T) {
 			}
 			cfg.Config = tt.existingConfig
 
-			err = cfg.SetActiveComponent(tt.component, tt.project)
+			err = cfg.SetActiveComponent(tt.component, tt.application, tt.project)
 			if tt.wantErr {
 				if (err != nil) != tt.wantErr {
 					t.Errorf("SetActiveComponent() unexpected error %v, wantErr %v", err, tt.wantErr)


### PR DESCRIPTION
This fixes bug where default application was created when listing apps or
just getting the current app.

- If `ocdev app` is run and there are no applications, a message is shown
  informing user about this fact. Previously it showed that default application is active.
- When `ocdev create ...` is run and there are no application, default
  the application is automatically created and used.

fixes #190 and #142 

TODO:
 - [x] fix tests 