### PR TITLE
if 'oc whoami' retruns error assume that user is not logged in

### DIFF
--- a/pkg/occlient/occlient.go
+++ b/pkg/occlient/occlient.go
@@ -127,7 +127,8 @@ func isLoggedIn() bool {
 
 	cmd := exec.Command(ocpath, "whoami")
 	output, err := cmd.CombinedOutput()
-	if err != nil && strings.Contains(string(output), "system:anonymous") {
+	log.Debugf("isLoggedIn err:  %#v \n output: %#v", err, string(output))
+	if err != nil {
 		log.Debug(errors.Wrap(err, "error running command"))
 		log.Debugf("Output is: %v", output)
 		return false


### PR DESCRIPTION
We should assume that if `oc whoami` returns an error code, then the user is not logged in regardless what output of `oc whoami` was.

fixes #125  and one part of #189 