### PR TITLE
implement 'ocdev component list'

### DIFF
--- a/cmd/component.go
+++ b/cmd/component.go
@@ -16,6 +16,7 @@ var (
 	componentGit       string
 	componentDir       string
 	componentShortFlag bool
+	componentApp       string
 )
 
 // componentCmd represents the component command
@@ -164,12 +165,38 @@ var componentSetCmd = &cobra.Command{
 	},
 }
 
+var componentListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List all component in current application.",
+	Args:  cobra.NoArgs,
+	Run: func(cmd *cobra.Command, args []string) {
+
+		components, err := component.List()
+		if err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+
+		if len(components) == 0 {
+			fmt.Println("There are no components deployed.")
+			return
+		}
+
+		fmt.Println("You have deployed:")
+		for _, comp := range components {
+			fmt.Printf("%s using the %s component\n", comp.Name, comp.Type)
+		}
+
+	},
+}
+
 func init() {
 	componentCreateCmd.Flags().StringVar(&componentBinary, "binary", "", "binary artifact")
 	componentCreateCmd.Flags().StringVar(&componentGit, "git", "", "git source")
 	componentCreateCmd.Flags().StringVar(&componentDir, "dir", "", "local directory as source")
 
 	componentGetCmd.Flags().BoolVarP(&componentShortFlag, "short", "q", false, "If true, display only the component name")
+
 	// add flags from 'get' to component command
 	componentCmd.Flags().AddFlagSet(applicationGetCmd.Flags())
 
@@ -177,6 +204,7 @@ func init() {
 	componentCmd.AddCommand(componentGetCmd)
 	componentCmd.AddCommand(componentCreateCmd)
 	componentCmd.AddCommand(componentSetCmd)
+	componentCmd.AddCommand(componentListCmd)
 
 	rootCmd.AddCommand(componentCmd)
 }

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -1,0 +1,6 @@
+package cmd
+
+// 'ocdev list' is just an alias for 'ocdev component list'
+func init() {
+	rootCmd.AddCommand(componentListCmd)
+}

--- a/pkg/application/application.go
+++ b/pkg/application/application.go
@@ -72,7 +72,7 @@ func List() ([]config.ApplicationInfo, error) {
 	applications = append(applications, cfg.ActiveApplications...)
 
 	// Get applications from cluster
-	appNames, err := occlient.GetLabelValues(project, ApplicationLabel)
+	appNames, err := occlient.GetLabelValues(project, ApplicationLabel, ApplicationLabel)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to list applications")
 	}

--- a/pkg/component/component.go
+++ b/pkg/component/component.go
@@ -13,6 +13,15 @@ import (
 // componentLabel is a label key used to identify component
 const componentLabel = "app.kubernetes.io/component-name"
 
+// componentTypeLabel is kubernetes that identifies type of a component
+const componentTypeLabel = "app.kubernetes.io/component-type"
+
+// ComponentInfo holds all important information about one component
+type ComponentInfo struct {
+	Name string
+	Type string
+}
+
 // GetLabels return labels that should be applied to every object for given component in active application
 // additional labels are used only for creating object
 // if you are creating something use additional=true
@@ -38,6 +47,9 @@ func CreateFromGit(name string, ctype string, url string) (string, error) {
 		return "", errors.Wrapf(err, "unable to activate component %s created from git", name)
 	}
 
+	// save component type as label
+	labels[componentTypeLabel] = ctype
+
 	output, err := occlient.NewAppS2I(name, ctype, url, labels)
 	if err != nil {
 		return "", err
@@ -54,6 +66,9 @@ func CreateEmpty(name string, ctype string) (string, error) {
 	if err != nil {
 		return "", errors.Wrapf(err, "unable to activate component %s created from git", name)
 	}
+
+	// save component type as label
+	labels[componentTypeLabel] = ctype
 
 	output, err := occlient.NewAppS2IEmpty(name, ctype, labels)
 	if err != nil {
@@ -164,4 +179,61 @@ func Push(name string, dir string) (string, error) {
 		return "", errors.Wrap(err, "unable to start build")
 	}
 	return output, nil
+}
+
+// GetComponentType returns type of component in given application and project
+func GetComponentType(componentName string, applicationName string, projectName string) (string, error) {
+	// filter according to component and application name
+	selector := fmt.Sprintf("%s=%s,%s=%s", componentLabel, componentName, application.ApplicationLabel, applicationName)
+	ctypes, err := occlient.GetLabelValues(projectName, componentTypeLabel, selector)
+	if err != nil {
+		return "", errors.Wrap(err, "unable to get type of %s component")
+	}
+	if len(ctypes) < 1 {
+		// no type returned
+		return "", errors.Wrap(err, "unable to find type of %s component")
+
+	}
+	// check if all types are the same
+	// it should be as we are secting only exactly one component, and it doesn't make sense
+	// to have one component labeled with different component type labels
+	for _, ctype := range ctypes {
+		if ctypes[0] != ctype {
+			return "", errors.Wrap(err, "data mismatch: %s component has objects with different types")
+		}
+
+	}
+	return ctypes[0], nil
+}
+
+// List lists components in active application
+func List() ([]ComponentInfo, error) {
+	// TODO: use project abstaction
+	currentProject, err := occlient.GetCurrentProjectName()
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to list components")
+	}
+
+	currentApplication, err := application.GetCurrent()
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to list components")
+	}
+
+	applicationSelector := fmt.Sprintf("%s=%s", application.ApplicationLabel, currentApplication)
+	componentNames, err := occlient.GetLabelValues(currentProject, componentLabel, applicationSelector)
+	if err != nil {
+		return nil, errors.Wrapf(err, "unable to list components")
+	}
+
+	components := []ComponentInfo{}
+
+	for _, name := range componentNames {
+		ctype, err := GetComponentType(name, currentApplication, currentProject)
+		if err != nil {
+			return nil, errors.Wrapf(err, "unable to list components")
+		}
+		components = append(components, ComponentInfo{Name: name, Type: ctype})
+	}
+
+	return components, nil
 }

--- a/pkg/occlient/occlient.go
+++ b/pkg/occlient/occlient.go
@@ -383,14 +383,14 @@ func SetVolumes(config *VolumeConfig, operations *VolumeOpertaions) (string, err
 	return string(output), nil
 }
 
-// GetLabelValues get label values from all object that are labeled with given label
+// GetLabelValues get label values of given label from objects in project that are matching selector
 // returns slice of uniq label values
-func GetLabelValues(project string, label string) ([]string, error) {
+func GetLabelValues(project string, label string, selector string) ([]string, error) {
 	// get all object that have given label
 	// and show just label values separated by ,
 	args := []string{
 		"get", "all",
-		"--selector", label,
+		"--selector", selector,
 		"--namespace", project,
 		"-o", "go-template={{range .items}}{{range $key, $value := .metadata.labels}}{{if eq $key \"" + label + "\"}}{{$value}},{{end}}{{end}}{{end}}",
 	}


### PR DESCRIPTION
fixes #53 
fixes #191 

implements:
`ocdev component list`/`ocdev list` -  list component names in current application and their types 

```
▶ ./ocdev list
You have deployed:
nodejs using the nodejs component
ffff using the nodejs component
wildfly using the wildfly component
```

TODO:
- [x] `component.GetComponentType` - needs to filter according to applicationName