### PR TITLE
Make push smart

### DIFF
--- a/cmd/component.go
+++ b/cmd/component.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -78,15 +79,26 @@ var componentCreateCmd = &cobra.Command{
 			}
 			fmt.Println(output)
 		} else if len(componentDir) != 0 {
-			output, err := component.CreateFromDir(client, componentName, componentType, componentDir)
+			// we want to use and save absolute path for component
+			dir, err := filepath.Abs(componentDir)
+			if err != nil {
+				fmt.Println(err)
+				os.Exit(1)
+			}
+			output, err := component.CreateFromDir(client, componentName, componentType, dir)
 			if err != nil {
 				fmt.Println(err)
 				os.Exit(1)
 			}
 			fmt.Println(output)
 		} else {
-			// no flag was set, use current directory
-			output, err := component.CreateFromDir(client, componentName, componentType, "./")
+			// we want to use and save absolute path for component
+			dir, err := filepath.Abs("./")
+			if err != nil {
+				fmt.Println(err)
+				os.Exit(1)
+			}
+			output, err := component.CreateFromDir(client, componentName, componentType, dir)
 			if err != nil {
 				fmt.Println(err)
 				os.Exit(1)

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -2,8 +2,10 @@ package cmd
 
 import (
 	"fmt"
+	"net/url"
 	"os"
 
+	"github.com/redhat-developer/ocdev/pkg/application"
 	"github.com/redhat-developer/ocdev/pkg/component"
 
 	"github.com/pkg/errors"
@@ -23,8 +25,20 @@ var pushCmd = &cobra.Command{
 	`,
 	Args: cobra.MaximumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		log.Debug("component push called")
 		client := getOcClient()
+		// TODO: use project abstraction
+		projectName, err := client.GetCurrentProjectName()
+		if err != nil {
+			fmt.Println(errors.Wrap(err, "unable to get current project"))
+			os.Exit(1)
+		}
+
+		applicationName, err := application.GetCurrent(client)
+		if err != nil {
+			fmt.Println(errors.Wrap(err, "unable to get current application"))
+			os.Exit(1)
+		}
+
 		var componentName string
 		if len(args) == 0 {
 			var err error
@@ -34,19 +48,56 @@ var pushCmd = &cobra.Command{
 				fmt.Println(errors.Wrap(err, "unable to get current component"))
 				os.Exit(1)
 			}
+			if componentName == "" {
+				fmt.Println("No component is set as active.")
+				fmt.Println("Use 'ocdev component set <component name> to set and existing component as active or call this command with component name as and argument.")
+				os.Exit(1)
+			}
 		} else {
 			componentName = args[0]
 		}
 		fmt.Printf("pushing changes to component: %v\n", componentName)
 
-		if len(componentDir) == 0 {
-			componentDir = "."
-		}
-
-		if _, err := component.Push(client, componentName, componentDir); err != nil {
-			fmt.Printf("failed to push component: %v", componentName)
+		sourceType, sourcePath, err := component.GetComponentSource(client, componentName, applicationName, projectName)
+		if err != nil {
+			fmt.Println(errors.Wrap(err, "unable to get current component"))
 			os.Exit(1)
 		}
+
+		switch sourceType {
+		case "local":
+			// use value of '--dir' as source if it was used
+			if len(componentDir) != 0 {
+				sourcePath = componentDir
+			}
+			u, err := url.Parse(sourcePath)
+			if err != nil {
+				fmt.Printf("Unable to parse source %s from component %s", sourcePath, componentName)
+				os.Exit(1)
+			}
+			if u.Scheme != "" && u.Scheme != "file" {
+				fmt.Printf("Component %s has invalid source path %s", componentName, u.Scheme)
+				os.Exit(1)
+			}
+
+			if err := component.PushLocal(client, componentName, u.Path); err != nil {
+				fmt.Printf("failed to push component: %v", componentName)
+				os.Exit(1)
+			}
+		case "git":
+			// currently we don't support changing build type
+			// it doesn't make sense to use --dir with git build
+			if len(componentDir) != 0 {
+				fmt.Println("unable to push local directory to component that uses git repository as source")
+				os.Exit(1)
+			}
+			if err := component.RebuildGit(client, componentName); err != nil {
+				fmt.Printf("failed to push component: %v", componentName)
+				os.Exit(1)
+			}
+
+		}
+
 		fmt.Printf("changes successfully pushed to component: %v\n", componentName)
 	},
 }

--- a/pkg/occlient/occlient.go
+++ b/pkg/occlient/occlient.go
@@ -385,7 +385,7 @@ func getExposedPorts(image *imagev1.ImageStreamImage) ([]corev1.ContainerPort, e
 
 // NewAppS2I create new application using S2I
 // if gitUrl is ""  than it creates binary build otherwise uses gitUrl as buildSource
-func (c *Client) NewAppS2I(name string, builderImage string, gitUrl string, labels map[string]string) (string, error) {
+func (c *Client) NewAppS2I(name string, builderImage string, gitUrl string, labels map[string]string, annotations map[string]string) (string, error) {
 	openShiftNameSpace := "openshift"
 
 	imageName, imageTag, _, err := parseImageName(builderImage)
@@ -430,12 +430,16 @@ func (c *Client) NewAppS2I(name string, builderImage string, gitUrl string, labe
 
 	}
 
+	// ObjectMetadata are the same for all generated objects
+	commonObjectMeta := metav1.ObjectMeta{
+		Name:        name,
+		Labels:      labels,
+		Annotations: annotations,
+	}
+
 	// generate and create ImageStream
 	is := imagev1.ImageStream{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:   name,
-			Labels: labels,
-		},
+		ObjectMeta: commonObjectMeta,
 	}
 	_, err = c.imageClient.ImageStreams(c.namespace).Create(&is)
 	if err != nil {
@@ -444,7 +448,7 @@ func (c *Client) NewAppS2I(name string, builderImage string, gitUrl string, labe
 
 	// generate BuildConfig
 	buildSource := buildv1.BuildSource{
-		Type:   "Binary",
+		Type:   buildv1.BuildSourceBinary,
 		Binary: &buildv1.BinaryBuildSource{},
 	}
 	// if gitUrl set change buildSource to git and use given repo
@@ -453,15 +457,12 @@ func (c *Client) NewAppS2I(name string, builderImage string, gitUrl string, labe
 			Git: &buildv1.GitBuildSource{
 				URI: gitUrl,
 			},
-			Type: "Git",
+			Type: buildv1.BuildSourceGit,
 		}
 	}
 
 	bc := buildv1.BuildConfig{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:   name,
-			Labels: labels,
-		},
+		ObjectMeta: commonObjectMeta,
 		Spec: buildv1.BuildConfigSpec{
 			CommonSpec: buildv1.CommonSpec{
 				Output: buildv1.BuildOutput{
@@ -499,10 +500,7 @@ func (c *Client) NewAppS2I(name string, builderImage string, gitUrl string, labe
 
 	// generate  and create DeploymentConfig
 	dc := appsv1.DeploymentConfig{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:   name,
-			Labels: labels,
-		},
+		ObjectMeta: commonObjectMeta,
 		Spec: appsv1.DeploymentConfigSpec{
 			Replicas: 1,
 			Selector: map[string]string{
@@ -562,10 +560,7 @@ func (c *Client) NewAppS2I(name string, builderImage string, gitUrl string, labe
 		svcPorts = append(svcPorts, svcPort)
 	}
 	svc := corev1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:   name,
-			Labels: labels,
-		},
+		ObjectMeta: commonObjectMeta,
 		Spec: corev1.ServiceSpec{
 			Ports: svcPorts,
 			Selector: map[string]string{
@@ -582,7 +577,8 @@ func (c *Client) NewAppS2I(name string, builderImage string, gitUrl string, labe
 
 }
 
-func (c *Client) StartBuild(name string, dir string) (string, error) {
+// StartBinaryBuild starts new build and streams dir as source for build
+func (c *Client) StartBinaryBuild(name string, dir string) error {
 	var r io.Reader
 	pr, pw := io.Pipe()
 	go func() {
@@ -616,16 +612,37 @@ func (c *Client) StartBuild(name string, dir string) (string, error) {
 		Into(result)
 
 	if err != nil {
-		return "", errors.Wrapf(err, "unable to start build %s", name)
+		return errors.Wrapf(err, "unable to start build %s", name)
 	}
-	log.Debug("Build %s from %s directory triggered.", name, dir)
+	log.Debugf("Build %s from %s directory triggered.", name, dir)
 
 	err = c.FollowBuildLog(result.Name)
 	if err != nil {
-		return "", errors.Wrapf(err, "unable to start build %s", name)
+		return errors.Wrapf(err, "unable to start build %s", name)
 	}
 
-	return "", nil
+	return nil
+}
+
+// StartBuild starts new build as it is
+func (c *Client) StartBuild(name string) error {
+	buildRequest := buildv1.BuildRequest{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+	}
+	result, err := c.buildClient.BuildConfigs(c.namespace).Instantiate(name, &buildRequest)
+	if err != nil {
+		return errors.Wrapf(err, "unable to start build %s", name)
+	}
+	log.Debugf("Build %s triggered.", name)
+
+	err = c.FollowBuildLog(result.Name)
+	if err != nil {
+		return errors.Wrapf(err, "unable to start build %s", name)
+	}
+
+	return nil
 }
 
 // FollowBuildLog stream build log to stdout
@@ -782,4 +799,14 @@ func (c *Client) GetLabelValues(project string, label string, selector string) (
 	}
 
 	return values, nil
+}
+
+// GetBuildConfig get BuildConfig by its name
+func (c *Client) GetBuildConfig(name string, project string) (*buildv1.BuildConfig, error) {
+	log.Debugf("Getting BuildConfig: %s", name)
+	bc, err := c.buildClient.BuildConfigs(c.namespace).Get(name, metav1.GetOptions{})
+	if err != nil {
+		return nil, errors.Wrapf(err, "unable to get BuildConfig %s", name)
+	}
+	return bc, nil
 }


### PR DESCRIPTION
When a component is created type and path to the source is saved to objects
annotations.
Later when `ocdev push` is called it detects what source was used and
uses the same source for a new build. (If it was a local source, the same dir is pushed to
BuildConfig, if it was built from remote git it starts new BuildConfig
with to rebuild from updated git.)

fixes https://github.com/redhat-developer/ocdev/issues/220
related to #222 and #221 
