### PR TITLE
Add `ocdev url` command

### DIFF
--- a/cmd/url.go
+++ b/cmd/url.go
@@ -1,0 +1,142 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/redhat-developer/ocdev/pkg/application"
+	"github.com/redhat-developer/ocdev/pkg/component"
+	"github.com/redhat-developer/ocdev/pkg/url"
+	"github.com/spf13/cobra"
+)
+
+var (
+	urlListComponent   string
+	urlListApplication string
+)
+
+var urlCmd = &cobra.Command{
+	Use:   "url",
+	Short: "Expose component to the outside world",
+	Long: `Expose component to the outside world.
+The URLs that are generated using this command, can be used to access the
+deployed components from outside the cluster.
+`,
+}
+
+var urlCreateCmd = &cobra.Command{
+	Use:   "create [component name]",
+	Short: "Create a URL for a component",
+	Long: `Create a URL for a component.
+The created URL can be used to access the specified component from outside the
+OpenShift cluster.
+`,
+	Example: `# Create a URL for the current component.
+ocdev url create
+
+# Create a URL for a specific component
+ocdev url create <component name>
+`,
+	Args: cobra.MaximumNArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		client := getOcClient()
+
+		var cmp string
+		switch len(args) {
+		case 0:
+			var err error
+			cmp, err = component.GetCurrent(client)
+			if err != nil {
+				fmt.Println(err)
+				os.Exit(1)
+			}
+		case 1:
+			cmp = args[0]
+		default:
+			fmt.Println("unable to get component")
+			os.Exit(1)
+		}
+
+		fmt.Printf("Adding URL to component: %v\n", cmp)
+		u, err := url.Create(client, cmp)
+		if err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+		fmt.Printf("URL created for component: %v\n\n"+
+			"%v - %v\n", cmp, u.Name, u.URL)
+	},
+}
+
+var urlDeleteCmd = &cobra.Command{
+	Use:   "delete <URL>",
+	Short: "Delete a URL",
+	Long: `Delete a URL.
+Deleted the given URL, hence making the service inaccessible.
+`,
+	Example: `# Delete a URL to a component
+ocdev url delete <URL>
+`,
+	Args: cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		client := getOcClient()
+		u := args[0]
+		if err := url.Delete(client, u); err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+		fmt.Printf("Deleted URL: %v\n", u)
+	},
+}
+
+var urlListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List URLs",
+	Long: `List URLs.
+Lists all the available URLs which can be used to access the components.`,
+	Example: ` # List the available URLs
+ocdev url list
+`,
+	Args: cobra.ExactArgs(0),
+	Run: func(cmd *cobra.Command, args []string) {
+		client := getOcClient()
+
+		var app string
+		if urlListApplication == "" {
+			var err error
+			app, err = application.GetCurrent(client)
+			if err != nil {
+				fmt.Println(err)
+				os.Exit(1)
+			}
+		} else {
+			app = urlListApplication
+		}
+
+		cmp := urlListComponent
+		urls, err := url.List(client, cmp, app)
+		if err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+
+		if len(urls) == 0 {
+			fmt.Printf("No URLs found for component %v in application %v\n", cmp, app)
+		} else {
+			fmt.Printf("Found the following URLs for component %v in application %v:\n", cmp, app)
+			for _, u := range urls {
+				fmt.Printf("%v - %v\n", u.Name, u.URL)
+			}
+		}
+	},
+}
+
+func init() {
+	urlListCmd.Flags().StringVarP(&urlListApplication, "application", "a", "", "list URLs for application")
+	urlListCmd.Flags().StringVarP(&urlListComponent, "component", "c", "", "list URLs for component")
+
+	urlCmd.AddCommand(urlListCmd)
+	urlCmd.AddCommand(urlDeleteCmd)
+	urlCmd.AddCommand(urlCreateCmd)
+	rootCmd.AddCommand(urlCmd)
+}

--- a/pkg/component/component.go
+++ b/pkg/component/component.go
@@ -13,8 +13,8 @@ import (
 	"github.com/redhat-developer/ocdev/pkg/occlient"
 )
 
-// componentLabel is a label key used to identify component
-const componentLabel = "app.kubernetes.io/component-name"
+// ComponentLabel is a label key used to identify component
+const ComponentLabel = "app.kubernetes.io/component-name"
 
 // componentTypeLabel is kubernetes that identifies type of a component
 const componentTypeLabel = "app.kubernetes.io/component-type"
@@ -38,7 +38,7 @@ func GetLabels(componentName string, applicationName string, additional bool) (m
 	if err != nil {
 		return nil, errors.Wrapf(err, "unable to get get labels for  component %s", componentName)
 	}
-	labels[componentLabel] = componentName
+	labels[ComponentLabel] = componentName
 
 	return labels, nil
 }
@@ -193,7 +193,7 @@ func GetCurrent(client *occlient.Client) (string, error) {
 	if err != nil {
 		return "", errors.Wrap(err, "unable to get config")
 	}
-	currentApplication, err := application.GetCurrent(client)
+	currentApplication, err := application.GetCurrentOrDefault(client)
 	if err != nil {
 		return "", errors.Wrap(err, "unable to get active application")
 	}
@@ -229,7 +229,7 @@ func RebuildGit(client *occlient.Client, componentName string) error {
 // GetComponentType returns type of component in given application and project
 func GetComponentType(client *occlient.Client, componentName string, applicationName string, projectName string) (string, error) {
 	// filter according to component and application name
-	selector := fmt.Sprintf("%s=%s,%s=%s", componentLabel, componentName, application.ApplicationLabel, applicationName)
+	selector := fmt.Sprintf("%s=%s,%s=%s", ComponentLabel, componentName, application.ApplicationLabel, applicationName)
 	ctypes, err := client.GetLabelValues(projectName, componentTypeLabel, selector)
 	if err != nil {
 		return "", errors.Wrap(err, "unable to get type of %s component")
@@ -265,7 +265,7 @@ func List(client *occlient.Client) ([]ComponentInfo, error) {
 	}
 
 	applicationSelector := fmt.Sprintf("%s=%s", application.ApplicationLabel, currentApplication)
-	componentNames, err := client.GetLabelValues(currentProject, componentLabel, applicationSelector)
+	componentNames, err := client.GetLabelValues(currentProject, ComponentLabel, applicationSelector)
 	if err != nil {
 		return nil, errors.Wrapf(err, "unable to list components")
 	}

--- a/pkg/url/url.go
+++ b/pkg/url/url.go
@@ -1,0 +1,73 @@
+package url
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+	"github.com/redhat-developer/ocdev/pkg/application"
+	"github.com/redhat-developer/ocdev/pkg/component"
+	"github.com/redhat-developer/ocdev/pkg/occlient"
+	log "github.com/sirupsen/logrus"
+)
+
+type URL struct {
+	Name string
+	URL  string
+}
+
+// Delete deletes a URL
+func Delete(client *occlient.Client, name string) error {
+	return client.DeleteRoute(name)
+}
+
+// Create creates a URL
+func Create(client *occlient.Client, cmp string) (*URL, error) {
+
+	app, err := application.GetCurrentOrDefault(client)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to get current application")
+	}
+
+	labels, err := component.GetLabels(cmp, app, false)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to get labels")
+	}
+
+	route, err := client.CreateRoute(cmp, labels)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to create route")
+	}
+
+	return &URL{
+		Name: route.Name,
+		URL:  route.Spec.Host,
+	}, nil
+}
+
+// List lists the URLs in an application. The results can further be narrowed
+// down if a component name is provided, which will only list URLs for the
+// given component
+func List(client *occlient.Client, componentName string, applicationName string) ([]URL, error) {
+
+	labelSelector := fmt.Sprintf("%v=%v", application.ApplicationLabel, applicationName)
+
+	if componentName != "" {
+		labelSelector = labelSelector + fmt.Sprintf(",%v=%v", component.ComponentLabel, componentName)
+	}
+
+	log.Debugf("Listing routes with label selector: %v", labelSelector)
+	routes, err := client.ListRoutes(labelSelector)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to list route names")
+	}
+
+	var urls []URL
+	for _, r := range routes {
+		urls = append(urls, URL{
+			Name: r.Name,
+			URL:  r.Spec.Host,
+		})
+	}
+
+	return urls, nil
+}


### PR DESCRIPTION
This commit adds the `ocdev url create/delete/list` commands which
can be used to add URLs to components.

Underneath, these commands manage OpenShift route objects to
achieve this functionality.

Fix #231 #65