### PR TITLE
Improve error handling in cmd/

### DIFF
--- a/cmd/application.go
+++ b/cmd/application.go
@@ -33,15 +33,10 @@ var applicationCreateCmd = &cobra.Command{
 		name := args[0]
 		client := getOcClient()
 		fmt.Printf("Creating application: %v\n", name)
-		if err := application.Create(client, name); err != nil {
-			fmt.Println(err)
-			os.Exit(1)
-		}
-		err := application.SetCurrent(client, name)
-		if err != nil {
-			fmt.Println(err)
-			os.Exit(1)
-		}
+		err := application.Create(client, name)
+		checkError(err, "")
+		err = application.SetCurrent(client, name)
+		checkError(err, "")
 		fmt.Printf("Switched to application: %v\n", name)
 	},
 }
@@ -53,10 +48,7 @@ var applicationGetCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		client := getOcClient()
 		app, err := application.GetCurrent(client)
-		if err != nil {
-			fmt.Println(err)
-			os.Exit(1)
-		}
+		checkError(err, "")
 		if applicationShortFlag {
 			fmt.Print(app)
 			return
@@ -92,10 +84,7 @@ var applicationDeleteCmd = &cobra.Command{
 
 		if strings.ToLower(confirmDeletion) == "y" {
 			err := application.Delete(client, appName)
-			if err != nil {
-				fmt.Println(err)
-				os.Exit(1)
-			}
+			checkError(err, "")
 			fmt.Printf("Deleted application: %s\n", args[0])
 		} else {
 			fmt.Printf("Aborting deletion of application: %v\n", appName)
@@ -110,10 +99,7 @@ var applicationListCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		client := getOcClient()
 		apps, err := application.List(client)
-		if err != nil {
-			fmt.Println(err)
-			os.Exit(1)
-		}
+		checkError(err, "")
 		fmt.Printf("ACTIVE   NAME\n")
 		for _, app := range apps {
 			activeMark := " "
@@ -141,20 +127,14 @@ var applicationSetCmd = &cobra.Command{
 		appName := args[0]
 		// error if application does not exist
 		exists, err := application.Exists(client, appName)
-		if err != nil {
-			fmt.Printf("Unable to check if application exists: %v\n", err)
-			os.Exit(1)
-		}
+		checkError(err, "unable to check if application exists")
 		if !exists {
 			fmt.Printf("Application %v does not exist\n", appName)
 			os.Exit(1)
 		}
 
 		err = application.SetCurrent(client, appName)
-		if err != nil {
-			fmt.Println(err)
-			os.Exit(1)
-		}
+		checkError(err, "")
 		fmt.Printf("Switched to application: %v\n", args[0])
 	},
 }

--- a/cmd/catalog.go
+++ b/cmd/catalog.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"github.com/pkg/errors"
 	"github.com/redhat-developer/ocdev/pkg/catalog"
 	"github.com/spf13/cobra"
 )
@@ -24,10 +23,7 @@ ocdev catalog list
 	Run: func(cmd *cobra.Command, args []string) {
 		client := getOcClient()
 		catalogList, err := catalog.List(client)
-		if err != nil {
-			fmt.Println(errors.Wrap(err, "unable to list components"))
-		}
-
+		checkError(err, "unable to list components")
 		switch len(catalogList) {
 		case 0:
 			fmt.Printf("No deployable components found\n")
@@ -56,9 +52,7 @@ ocdev catalog search pyt
 		client := getOcClient()
 		searchTerm := args[0]
 		components, err := catalog.Search(client, searchTerm)
-		if err != nil {
-			fmt.Println(errors.Wrap(err, "unable to search for components"))
-		}
+		checkError(err, "unable to search for components")
 
 		switch len(components) {
 		case 0:

--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -25,9 +25,7 @@ Will load the shell completion code.
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		err := Generate(cmd, args)
-		if err != nil {
-			fmt.Printf("Error: %s", err)
-		}
+		checkError(err, "")
 
 		return nil
 	},

--- a/cmd/component.go
+++ b/cmd/component.go
@@ -2,9 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"os"
-
-	"github.com/pkg/errors"
 	"github.com/redhat-developer/ocdev/pkg/component"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -33,10 +30,7 @@ var componentGetCmd = &cobra.Command{
 		log.Debugf("component get called")
 		client := getOcClient()
 		component, err := component.GetCurrent(client)
-		if err != nil {
-			fmt.Println(errors.Wrap(err, "unable to get current component"))
-			os.Exit(1)
-		}
+		checkError(err, "unable to get current component")
 		if componentShortFlag {
 			fmt.Print(component)
 		} else {
@@ -60,10 +54,7 @@ var componentSetCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		client := getOcClient()
 		err := component.SetCurrent(client, args[0])
-		if err != nil {
-			fmt.Println(err)
-			os.Exit(1)
-		}
+		checkError(err, "")
 		fmt.Printf("Switched to component: %v\n", args[0])
 	},
 }

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -60,44 +60,26 @@ If component name is not provided, component type value will be used for name.
 
 		if len(componentGit) != 0 {
 			output, err := component.CreateFromGit(client, componentName, componentType, componentGit)
-			if err != nil {
-				fmt.Println(err)
-				os.Exit(1)
-			}
+			checkError(err, "")
 			fmt.Println(output)
 		} else if len(componentLocal) != 0 {
 			// we want to use and save absolute path for component
 			dir, err := filepath.Abs(componentLocal)
-			if err != nil {
-				fmt.Println(err)
-				os.Exit(1)
-			}
+			checkError(err, "")
 			output, err := component.CreateFromDir(client, componentName, componentType, dir)
-			if err != nil {
-				fmt.Println(err)
-				os.Exit(1)
-			}
+			checkError(err, "")
 			fmt.Println(output)
 		} else {
 			// we want to use and save absolute path for component
 			dir, err := filepath.Abs("./")
-			if err != nil {
-				fmt.Println(err)
-				os.Exit(1)
-			}
+			checkError(err, "")
 			output, err := component.CreateFromDir(client, componentName, componentType, dir)
-			if err != nil {
-				fmt.Println(err)
-				os.Exit(1)
-			}
+			checkError(err, "")
 			fmt.Println(output)
 		}
 		// after component is successfully created, set is as active
-		if err := component.SetCurrent(client, componentName); err != nil {
-			fmt.Println(err)
-			os.Exit(1)
-		}
-
+		err := component.SetCurrent(client, componentName)
+		checkError(err, "")
 	},
 }
 

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/redhat-developer/ocdev/pkg/application"
@@ -32,10 +31,7 @@ var componentDeleteCmd = &cobra.Command{
 		var confirmDeletion string
 
 		currentApp, err := application.GetCurrent(client)
-		if err != nil {
-			fmt.Println(err)
-			os.Exit(1)
-		}
+		checkError(err, "")
 
 		if componentForceDeleteFlag {
 			confirmDeletion = "y"
@@ -46,10 +42,7 @@ var componentDeleteCmd = &cobra.Command{
 
 		if strings.ToLower(confirmDeletion) == "y" {
 			output, err := component.Delete(client, componentName)
-			if err != nil {
-				fmt.Println(err)
-				os.Exit(1)
-			}
+			checkError(err, "")
 			fmt.Println(output)
 		} else {
 			fmt.Printf("Aborting deletion of component: %v\n", componentName)

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -2,8 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"os"
-
 	"github.com/redhat-developer/ocdev/pkg/component"
 	"github.com/spf13/cobra"
 )
@@ -17,10 +15,7 @@ var componentListCmd = &cobra.Command{
 		client := getOcClient()
 
 		components, err := component.List(client)
-		if err != nil {
-			fmt.Println(err)
-			os.Exit(1)
-		}
+		checkError(err, "")
 
 		if len(components) == 0 {
 			fmt.Println("There are no components deployed.")

--- a/cmd/project.go
+++ b/cmd/project.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/redhat-developer/ocdev/pkg/project"
 	"github.com/spf13/cobra"
@@ -28,10 +27,7 @@ var projectSetCmd = &cobra.Command{
 		current := project.GetCurrent(client)
 
 		err := project.SetCurrent(client, projectName)
-		if err != nil {
-			fmt.Println(err)
-			os.Exit(1)
-		}
+		checkError(err, "")
 		if projectShortFlag {
 			fmt.Print(projectName)
 		} else {
@@ -68,15 +64,9 @@ var projectCreateCmd = &cobra.Command{
 		projectName := args[0]
 		client := getOcClient()
 		err := project.Create(client, projectName)
-		if err != nil {
-			fmt.Println(err)
-			os.Exit(1)
-		}
+		checkError(err, "")
 		err = project.SetCurrent(client, projectName)
-		if err != nil {
-			fmt.Println(err)
-			os.Exit(1)
-		}
+		checkError(err, "")
 		fmt.Printf("New project created and now using project : %v\n", projectName)
 	},
 }
@@ -88,10 +78,7 @@ var projectListCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		client := getOcClient()
 		projects, err := project.List(client)
-		if err != nil {
-			fmt.Println(err)
-			os.Exit(1)
-		}
+		checkError(err, "")
 		fmt.Printf("ACTIVE   NAME\n")
 		for _, app := range projects {
 			activeMark := " "

--- a/cmd/storage.go
+++ b/cmd/storage.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/redhat-developer/ocdev/pkg/component"
 	"github.com/redhat-developer/ocdev/pkg/occlient"
@@ -19,10 +18,7 @@ var (
 func getComponent(client *occlient.Client) string {
 	if len(storageComponent) == 0 {
 		c, err := component.GetCurrent(client)
-		if err != nil {
-			fmt.Printf("Could not get current component: %v\n", err)
-			os.Exit(1)
-		}
+		checkError(err, "Could not get current component")
 		return c
 	}
 	return storageComponent
@@ -48,10 +44,7 @@ var storageAddCmd = &cobra.Command{
 				Path:             &storagePath,
 				Size:             &storageSize,
 			})
-		if err != nil {
-			fmt.Printf("Failed to add storage: %v\n", err)
-			os.Exit(1)
-		}
+		checkError(err, "Failed to add storage")
 		fmt.Printf("Added storage %v to %v\n", args[0], cmpnt)
 	},
 }
@@ -74,10 +67,8 @@ var storageRemoveCmd = &cobra.Command{
 				Name:             storageName,
 				DeploymentConfig: &cmpnt,
 			})
-		if err != nil {
-			fmt.Printf("Failed to remove storage: %v\n", err)
-			os.Exit(1)
-		}
+		checkError(err, "Failed to remove storage")
+
 		if len(args) == 0 {
 			fmt.Printf("Removed all storage from %v\n", cmpnt)
 		} else {
@@ -97,10 +88,7 @@ var storageListCmd = &cobra.Command{
 			&occlient.VolumeConfig{
 				DeploymentConfig: &cmpnt,
 			})
-		if err != nil {
-			fmt.Printf("Failed to list storage: %v\n", err)
-			os.Exit(1)
-		}
+		checkError(err, "Failed to list storage")
 		fmt.Println(output)
 	},
 }

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -55,45 +55,28 @@ var updateCmd = &cobra.Command{
 		)
 		if len(args) == 0 {
 			componentName, err = component.GetCurrent(client)
-			if err != nil {
-				fmt.Println("Unable to get current component")
-			}
+			checkError(err, "unable to get current component")
 		} else {
 			componentName = args[0]
 		}
 
 		if len(componentGit) != 0 {
 			err := component.Update(client, componentName, "git", componentGit)
-			if err != nil {
-				fmt.Println(err)
-				os.Exit(1)
-			}
+			checkError(err, "")
 			fmt.Printf("The component %s was updated successfully\n", componentName)
 		} else if len(componentLocal) != 0 {
 			// we want to use and save absolute path for component
 			dir, err := filepath.Abs(componentLocal)
-			if err != nil {
-				fmt.Println(err)
-				os.Exit(1)
-			}
+			checkError(err, "")
 			err = component.Update(client, componentName, "dir", dir)
-			if err != nil {
-				fmt.Println(err)
-				os.Exit(1)
-			}
+			checkError(err, "")
 			fmt.Printf("The component %s was updated successfully\n", componentName)
 		} else {
 			// we want to use and save absolute path for component
 			dir, err := filepath.Abs("./")
-			if err != nil {
-				fmt.Println(err)
-				os.Exit(1)
-			}
+			checkError(err, "")
 			err = component.Update(client, componentName, "dir", dir)
-			if err != nil {
-				fmt.Println(err)
-				os.Exit(1)
-			}
+			checkError(err, "")
 			fmt.Printf("The component %s was updated successfully\n", componentName)
 		}
 	},

--- a/cmd/url.go
+++ b/cmd/url.go
@@ -46,10 +46,7 @@ ocdev url create <component name>
 		case 0:
 			var err error
 			cmp, err = component.GetCurrent(client)
-			if err != nil {
-				fmt.Println(err)
-				os.Exit(1)
-			}
+			checkError(err, "")
 		case 1:
 			cmp = args[0]
 		default:
@@ -59,10 +56,7 @@ ocdev url create <component name>
 
 		fmt.Printf("Adding URL to component: %v\n", cmp)
 		u, err := url.Create(client, cmp)
-		if err != nil {
-			fmt.Println(err)
-			os.Exit(1)
-		}
+		checkError(err, "")
 		fmt.Printf("URL created for component: %v\n\n"+
 			"%v - %v\n", cmp, u.Name, u.URL)
 	},
@@ -81,10 +75,8 @@ ocdev url delete <URL>
 	Run: func(cmd *cobra.Command, args []string) {
 		client := getOcClient()
 		u := args[0]
-		if err := url.Delete(client, u); err != nil {
-			fmt.Println(err)
-			os.Exit(1)
-		}
+		err := url.Delete(client, u)
+		checkError(err, "")
 		fmt.Printf("Deleted URL: %v\n", u)
 	},
 }
@@ -105,20 +97,14 @@ ocdev url list
 		if urlListApplication == "" {
 			var err error
 			app, err = application.GetCurrent(client)
-			if err != nil {
-				fmt.Println(err)
-				os.Exit(1)
-			}
+			checkError(err, "")
 		} else {
 			app = urlListApplication
 		}
 
 		cmp := urlListComponent
 		urls, err := url.List(client, cmp, app)
-		if err != nil {
-			fmt.Println(err)
-			os.Exit(1)
-		}
+		checkError(err, "")
 
 		if len(urls) == 0 {
 			fmt.Printf("No URLs found for component %v in application %v\n", cmp, app)


### PR DESCRIPTION
The way errors are currently being handled in `package cmd` is
first the error is printed and then `os.Exit(1)` is called.

This is repeated pattern and makes a code unreadable to some
extent.

This commit extracts the error handling logic to a separate
function and calls that function whenever an error has to be
handled. This improved the readability by quite a bit.