### PR TITLE
Remove all aliases to get/list/create/set/delete commands

### DIFF
--- a/cmd/application.go
+++ b/cmd/application.go
@@ -18,7 +18,7 @@ var (
 // applicationCmd represents the app command
 var applicationCmd = &cobra.Command{
 	Use:     "application",
-	Short:   "application",
+	Short:   "Perform application operations",
 	Aliases: []string{"app"},
 	// 'ocdev application' is the same as 'ocdev application get'
 	Run: applicationGetCmd.Run,

--- a/cmd/component.go
+++ b/cmd/component.go
@@ -3,23 +3,11 @@ package cmd
 import (
 	"fmt"
 	"os"
-	"path/filepath"
-	"strings"
 
 	"github.com/pkg/errors"
-	"github.com/redhat-developer/ocdev/pkg/application"
 	"github.com/redhat-developer/ocdev/pkg/component"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-)
-
-var (
-	componentApp             string
-	componentBinary          string
-	componentGit             string
-	componentLocal           string
-	componentShortFlag       bool
-	componentForceDeleteFlag bool
 )
 
 // componentCmd represents the component command
@@ -27,145 +15,11 @@ var componentCmd = &cobra.Command{
 	Use:   "component",
 	Short: "Components of application.",
 	// 'ocdev component' is the same as 'ocdev component get'
-	Run: componentGetCmd.Run,
-}
-
-var componentCreateCmd = &cobra.Command{
-	Use:   "create <component_type> [component_name] [flags]",
-	Short: "Create new component",
-	Long: `Create new component.
-If component name is not provided, component type value will be used for name.
-	`,
-	Example: `  # Create new nodejs component with the source in current directory. 
-  ocdev create nodejs
-
-  # Create new nodejs component named 'frontend' with the source in './frontend' directory
-  ocdev create nodejs frontend --local ./frontend
-
-  # Create new nodejs component with source from remote git repository.
-  ocdev create nodejs --git https://github.com/openshift/nodejs-ex.git
-	`,
-	Args: func(cmd *cobra.Command, args []string) error {
-		if len(args) < 1 {
-			// TODO: improve this message. It should say something about requiring component name
-			return fmt.Errorf("At least one argument is required")
-		}
-		if len(args) > 2 {
-			// TODO: Improve this message
-			return fmt.Errorf("Invalid arguments, maximum 2 arguments possible")
-		}
-		return nil
-	},
 	Run: func(cmd *cobra.Command, args []string) {
-		log.Debugf("Component create called with args: %#v, flags: binary=%s, git=%s, local=%s", strings.Join(args, " "), componentBinary, componentGit, componentLocal)
-
-		client := getOcClient()
-		if len(componentBinary) != 0 {
-			fmt.Printf("--binary is not implemented yet\n\n")
-			cmd.Help()
-			os.Exit(1)
-		}
-
-		//TODO: check flags - only one of binary, git, dir can be specified
-
-		//We don't have to check it anymore, Args check made sure that args has at least one item
-		// and no more than two
-		componentType := args[0]
-		componentName := args[0]
-		if len(args) == 2 {
-			componentName = args[1]
-		}
-
-		if len(componentBinary) != 0 {
-			fmt.Printf("--binary is not implemented yet\n\n")
-			os.Exit(1)
-		}
-
-		if len(componentGit) != 0 {
-			output, err := component.CreateFromGit(client, componentName, componentType, componentGit)
-			if err != nil {
-				fmt.Println(err)
-				os.Exit(1)
-			}
-			fmt.Println(output)
-		} else if len(componentLocal) != 0 {
-			// we want to use and save absolute path for component
-			dir, err := filepath.Abs(componentLocal)
-			if err != nil {
-				fmt.Println(err)
-				os.Exit(1)
-			}
-			output, err := component.CreateFromDir(client, componentName, componentType, dir)
-			if err != nil {
-				fmt.Println(err)
-				os.Exit(1)
-			}
-			fmt.Println(output)
+		if len(args) > 0 && args[0] != "get" && args[0] != "set" {
+			componentSetCmd.Run(cmd, args)
 		} else {
-			// we want to use and save absolute path for component
-			dir, err := filepath.Abs("./")
-			if err != nil {
-				fmt.Println(err)
-				os.Exit(1)
-			}
-			output, err := component.CreateFromDir(client, componentName, componentType, dir)
-			if err != nil {
-				fmt.Println(err)
-				os.Exit(1)
-			}
-			fmt.Println(output)
-		}
-		// after component is successfully created, set is as active
-		if err := component.SetCurrent(client, componentName); err != nil {
-			fmt.Println(err)
-			os.Exit(1)
-		}
-
-	},
-}
-
-var componentDeleteCmd = &cobra.Command{
-	Use:   "delete <component_name>",
-	Short: "Delete existing component",
-	Long:  "Delete existing component.",
-	Example: `  # Delete component named 'frontend'. 
-  ocdev delete frontend
-	`,
-	Args: func(cmd *cobra.Command, args []string) error {
-		if len(args) != 1 {
-			return fmt.Errorf("Please specify component name to delete.")
-		}
-		return nil
-	},
-	Run: func(cmd *cobra.Command, args []string) {
-		log.Debugf("component delete called")
-		log.Debugf("args: %#v", strings.Join(args, " "))
-		client := getOcClient()
-		componentName := args[0]
-		var confirmDeletion string
-
-		currentApp, err := application.GetCurrent(client)
-		if err != nil {
-			fmt.Println(err)
-			os.Exit(1)
-		}
-
-		if componentForceDeleteFlag {
-			confirmDeletion = "y"
-		} else {
-			fmt.Printf("Are you sure you want to delete %v from %v? [y/N] ", componentName, currentApp)
-			fmt.Scanln(&confirmDeletion)
-		}
-
-		if strings.ToLower(confirmDeletion) == "y" {
-			output, err := component.Delete(client, componentName)
-			if err != nil {
-				fmt.Println(err)
-				os.Exit(1)
-			}
-			fmt.Println(output)
-		} else {
-			fmt.Printf("Aborting deletion of component: %v\n", componentName)
+			componentGetCmd.Run(cmd, args)
 		}
 	},
 }
@@ -221,50 +75,15 @@ var componentSetCmd = &cobra.Command{
 	},
 }
 
-var componentListCmd = &cobra.Command{
-	Use:   "list",
-	Short: "List all component in current application",
-	Long:  "List all component in current application.",
-	Args:  cobra.NoArgs,
-	Run: func(cmd *cobra.Command, args []string) {
-		client := getOcClient()
-
-		components, err := component.List(client)
-		if err != nil {
-			fmt.Println(err)
-			os.Exit(1)
-		}
-
-		if len(components) == 0 {
-			fmt.Println("There are no components deployed.")
-			return
-		}
-
-		fmt.Println("You have deployed:")
-		for _, comp := range components {
-			fmt.Printf("%s using the %s component\n", comp.Name, comp.Type)
-		}
-
-	},
-}
-
 func init() {
-	componentDeleteCmd.Flags().BoolVarP(&componentForceDeleteFlag, "force", "f", false, "Delete component without prompting")
-
-	componentCreateCmd.Flags().StringVar(&componentBinary, "binary", "", "binary artifact")
-	componentCreateCmd.Flags().StringVar(&componentGit, "git", "", "git source")
-	componentCreateCmd.Flags().StringVar(&componentLocal, "local", "", "Use local directory as a source for component.")
 
 	componentGetCmd.Flags().BoolVarP(&componentShortFlag, "short", "q", false, "If true, display only the component name")
 
 	// add flags from 'get' to component command
 	componentCmd.Flags().AddFlagSet(applicationGetCmd.Flags())
 
-	componentCmd.AddCommand(componentDeleteCmd)
 	componentCmd.AddCommand(componentGetCmd)
-	componentCmd.AddCommand(componentCreateCmd)
 	componentCmd.AddCommand(componentSetCmd)
-	componentCmd.AddCommand(componentListCmd)
 
 	rootCmd.AddCommand(componentCmd)
 }

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -1,6 +1,120 @@
 package cmd
 
-// 'ocdev crate' is just an alias for 'ocdev component create'
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/redhat-developer/ocdev/pkg/component"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+var (
+	componentBinary string
+	componentGit    string
+	componentLocal  string
+)
+
+var componentCreateCmd = &cobra.Command{
+	Use:   "create <component_type> [component_name] [flags]",
+	Short: "Create new component",
+	Long: `Create new component.
+If component name is not provided, component type value will be used for name.
+	`,
+	Example: `  # Create new nodejs component with the source in current directory. 
+  ocdev create nodejs
+
+  # Create new nodejs component named 'frontend' with the source in './frontend' directory
+  ocdev create nodejs frontend --local ./frontend
+
+  # Create new nodejs component with source from remote git repository.
+  ocdev create nodejs --git https://github.com/openshift/nodejs-ex.git
+	`,
+	Args: func(cmd *cobra.Command, args []string) error {
+		if len(args) < 1 {
+			// TODO: improve this message. It should say something about requiring component name
+			return fmt.Errorf("At least one argument is required")
+		}
+		if len(args) > 2 {
+			// TODO: Improve this message
+			return fmt.Errorf("Invalid arguments, maximum 2 arguments possible")
+		}
+		return nil
+	},
+	Run: func(cmd *cobra.Command, args []string) {
+		log.Debugf("Component create called with args: %#v, flags: binary=%s, git=%s, local=%s", strings.Join(args, " "), componentBinary, componentGit, componentLocal)
+
+		client := getOcClient()
+		if len(componentBinary) != 0 {
+			fmt.Printf("--binary is not implemented yet\n\n")
+			cmd.Help()
+			os.Exit(1)
+		}
+
+		//TODO: check flags - only one of binary, git, dir can be specified
+
+		//We don't have to check it anymore, Args check made sure that args has at least one item
+		// and no more than two
+		componentType := args[0]
+		componentName := args[0]
+		if len(args) == 2 {
+			componentName = args[1]
+		}
+
+		if len(componentBinary) != 0 {
+			fmt.Printf("--binary is not implemented yet\n\n")
+			os.Exit(1)
+		}
+
+		if len(componentGit) != 0 {
+			output, err := component.CreateFromGit(client, componentName, componentType, componentGit)
+			if err != nil {
+				fmt.Println(err)
+				os.Exit(1)
+			}
+			fmt.Println(output)
+		} else if len(componentLocal) != 0 {
+			// we want to use and save absolute path for component
+			dir, err := filepath.Abs(componentLocal)
+			if err != nil {
+				fmt.Println(err)
+				os.Exit(1)
+			}
+			output, err := component.CreateFromDir(client, componentName, componentType, dir)
+			if err != nil {
+				fmt.Println(err)
+				os.Exit(1)
+			}
+			fmt.Println(output)
+		} else {
+			// we want to use and save absolute path for component
+			dir, err := filepath.Abs("./")
+			if err != nil {
+				fmt.Println(err)
+				os.Exit(1)
+			}
+			output, err := component.CreateFromDir(client, componentName, componentType, dir)
+			if err != nil {
+				fmt.Println(err)
+				os.Exit(1)
+			}
+			fmt.Println(output)
+		}
+		// after component is successfully created, set is as active
+		if err := component.SetCurrent(client, componentName); err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+
+	},
+}
+
 func init() {
+	componentCreateCmd.Flags().StringVar(&componentBinary, "binary", "", "Binary artifact")
+	componentCreateCmd.Flags().StringVar(&componentGit, "git", "", "Git source")
+	componentCreateCmd.Flags().StringVar(&componentLocal, "local", "", "Use local directory as a source for component")
+
 	rootCmd.AddCommand(componentCreateCmd)
 }

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -1,0 +1,68 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/redhat-developer/ocdev/pkg/application"
+	"github.com/redhat-developer/ocdev/pkg/component"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+var (
+	componentShortFlag       bool
+	componentForceDeleteFlag bool
+)
+
+var componentDeleteCmd = &cobra.Command{
+	Use:   "delete <component_name>",
+	Short: "Delete existing component",
+	Long:  "Delete existing component.",
+	Example: `  # Delete component named 'frontend'. 
+  ocdev delete frontend
+	`,
+	Args: func(cmd *cobra.Command, args []string) error {
+		if len(args) != 1 {
+			return fmt.Errorf("Please specify component name to delete.")
+		}
+		return nil
+	},
+	Run: func(cmd *cobra.Command, args []string) {
+		log.Debugf("component delete called")
+		log.Debugf("args: %#v", strings.Join(args, " "))
+		client := getOcClient()
+		componentName := args[0]
+		var confirmDeletion string
+
+		currentApp, err := application.GetCurrent(client)
+		if err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+
+		if componentForceDeleteFlag {
+			confirmDeletion = "y"
+		} else {
+			fmt.Printf("Are you sure you want to delete %v from %v? [y/N] ", componentName, currentApp)
+			fmt.Scanln(&confirmDeletion)
+		}
+
+		if strings.ToLower(confirmDeletion) == "y" {
+			output, err := component.Delete(client, componentName)
+			if err != nil {
+				fmt.Println(err)
+				os.Exit(1)
+			}
+			fmt.Println(output)
+		} else {
+			fmt.Printf("Aborting deletion of component: %v\n", componentName)
+		}
+	},
+}
+
+func init() {
+	componentDeleteCmd.Flags().BoolVarP(&componentForceDeleteFlag, "force", "f", false, "Delete component without prompting")
+	rootCmd.AddCommand(componentDeleteCmd)
+}

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -1,6 +1,40 @@
 package cmd
 
-// 'ocdev list' is just an alias for 'ocdev component list'
+import (
+	"fmt"
+	"os"
+
+	"github.com/redhat-developer/ocdev/pkg/component"
+	"github.com/spf13/cobra"
+)
+
+var componentListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List all components in the current application",
+	Long:  "List all components in the current application.",
+	Args:  cobra.NoArgs,
+	Run: func(cmd *cobra.Command, args []string) {
+		client := getOcClient()
+
+		components, err := component.List(client)
+		if err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+
+		if len(components) == 0 {
+			fmt.Println("There are no components deployed.")
+			return
+		}
+
+		fmt.Println("You have deployed:")
+		for _, comp := range components {
+			fmt.Printf("%s using the %s component\n", comp.Name, comp.Type)
+		}
+
+	},
+}
+
 func init() {
 	rootCmd.AddCommand(componentListCmd)
 }

--- a/cmd/project.go
+++ b/cmd/project.go
@@ -14,7 +14,7 @@ var (
 
 var projectCmd = &cobra.Command{
 	Use:   "project [options]",
-	Short: "project",
+	Short: "Perform project operations",
 	Run:   projectGetCmd.Run,
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -19,7 +19,7 @@ var (
 var rootCmd = &cobra.Command{
 	Use:   "ocdev",
 	Short: "OpenShift CLI for Developers",
-	Long:  `-`,
+	Long:  `OpenShift CLI for Developers`,
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
 
 		// Add extra logging when verbosity is passed
@@ -57,7 +57,7 @@ func init() {
 	// will be global for your application.
 	// rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.ocdev.yaml)")
 
-	rootCmd.PersistentFlags().BoolVarP(&GlobalVerbose, "verbose", "v", false, "verbose output")
+	rootCmd.PersistentFlags().BoolVarP(&GlobalVerbose, "verbose", "v", false, "Verbose output")
 }
 
 func getLatestReleaseInfo(info chan<- string) {

--- a/cmd/storage.go
+++ b/cmd/storage.go
@@ -30,8 +30,8 @@ func getComponent(client *occlient.Client) string {
 
 var storageCmd = &cobra.Command{
 	Use:   "storage",
-	Short: "storage",
-	Long:  "perform storage operations",
+	Short: "Perform storage operations",
+	Long:  "Perform storage operations",
 }
 
 var storageAddCmd = &cobra.Command{
@@ -106,15 +106,15 @@ var storageListCmd = &cobra.Command{
 }
 
 func init() {
-	storageAddCmd.Flags().StringVar(&storageSize, "size", "", "size of storage to add")
+	storageAddCmd.Flags().StringVar(&storageSize, "size", "", "Size of storage to add")
 	storageAddCmd.MarkFlagRequired("size")
-	storageAddCmd.Flags().StringVar(&storagePath, "path", "", "path to mount the storage on")
+	storageAddCmd.Flags().StringVar(&storagePath, "path", "", "Path to mount the storage on")
 	storageAddCmd.MarkFlagRequired("path")
 
 	storageCmd.AddCommand(storageAddCmd)
 	storageCmd.AddCommand(storageRemoveCmd)
 	storageCmd.AddCommand(storageListCmd)
 
-	storageCmd.PersistentFlags().StringVar(&storageComponent, "component", "", "component to add storage to, defaults to active component")
+	storageCmd.PersistentFlags().StringVar(&storageComponent, "component", "", "Component to add storage to, defaults to active component")
 	rootCmd.AddCommand(storageCmd)
 }

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -148,7 +148,7 @@ var _ = Describe("Usecase #5", func() {
 
 		Context("when application exists", func() {
 			It("should create a component", func() {
-				runCmd("ocdev component create nodejs --local " + tmpDir + "/nodejs-ex")
+				runCmd("ocdev create nodejs --local " + tmpDir + "/nodejs-ex")
 				Expect(getCmp()).To(Equal("nodejs"))
 				time.Sleep(10)
 			})
@@ -160,7 +160,7 @@ var _ = Describe("Usecase #5", func() {
 
 			Context("when all the components are listed", func() {
 				It("should list the components within the application", func() {
-					cmpList := runCmd("ocdev component list")
+					cmpList := runCmd("ocdev list")
 					Expect(cmpList).To(ContainSubstring("nodejs"))
 				})
 			})


### PR DESCRIPTION
This PR removes the `ocdev component X` commands for the following
commands:

```sh
Available Commands:
  application Perform application operations
  catalog     Catalog related operations
  completion  Output shell completion code
  create      Create new component
  delete      Delete existing component
  get         Get currently active component
  help        Help about any command
  list        List all components in the current application
  project     Perform project operations
  push        Push source code to component
  set         Set active component.
  storage     Perform storage operations
  url         Expose component to the outside world
  version     Print the version of ocdev
```