### PR TITLE
speed up running unit tests on travis-ci

### DIFF
--- a/scripts/generate-coverage.sh
+++ b/scripts/generate-coverage.sh
@@ -5,7 +5,7 @@
 
 set -e
 echo "" > coverage.txt
-
+go test -i -race 
 for d in $(go list ./... | grep -v vendor); do
     go test -race -coverprofile=profile.out -covermode=atomic $d
     if [ -f profile.out ]; then


### PR DESCRIPTION
run go test -i before running unit tests with coverage

this saves about 20%  `generate-coverage.sh` run time