### PR TITLE
Rename project commands

### DIFF
--- a/cmd/project.go
+++ b/cmd/project.go
@@ -75,7 +75,7 @@ var projectCreateCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		projectName := args[0]
 		client := getOcClient()
-		err := project.CreateProject(client, projectName)
+		err := project.Create(client, projectName)
 		if err != nil {
 			fmt.Println(err)
 			os.Exit(1)
@@ -95,7 +95,7 @@ var projectListCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(0),
 	Run: func(cmd *cobra.Command, args []string) {
 		client := getOcClient()
-		projects, err := project.ListProjects(client)
+		projects, err := project.List(client)
 		if err != nil {
 			fmt.Println(err)
 			os.Exit(1)

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -28,7 +28,7 @@ func SetCurrent(client *occlient.Client, project string) error {
 	return nil
 }
 
-func CreateProject(client *occlient.Client, projectName string) error {
+func Create(client *occlient.Client, projectName string) error {
 	err := client.CreateNewProject(projectName)
 	if err != nil {
 		return errors.Wrap(err, "unable to create new project")
@@ -36,7 +36,7 @@ func CreateProject(client *occlient.Client, projectName string) error {
 	return nil
 }
 
-func ListProjects(client *occlient.Client) ([]ProjectInfo, error) {
+func List(client *occlient.Client) ([]ProjectInfo, error) {
 	currentProject := client.GetCurrentProjectName()
 	allProjects, err := client.GetProjectNames()
 	if err != nil {


### PR DESCRIPTION
This commit renames the commands in project package to be more
consistent with the other packages.
- ListProjects() is now List()
- CreateProjects() is now Create()