### PR TITLE
Remove unnecessary return from both GetLabels()

### DIFF
--- a/pkg/application/application.go
+++ b/pkg/application/application.go
@@ -28,7 +28,7 @@ func getDefaultAppName() string {
 // additional labels are used only when creating object
 // if you are creating something use additional=true
 // if you need labels to filter component than use additional=false
-func GetLabels(application string, additional bool) (map[string]string, error) {
+func GetLabels(application string, additional bool) map[string]string {
 	labels := map[string]string{
 		ApplicationLabel: application,
 	}
@@ -39,7 +39,7 @@ func GetLabels(application string, additional bool) (map[string]string, error) {
 		}
 	}
 
-	return labels, nil
+	return labels
 }
 
 // Create a new application
@@ -112,10 +112,7 @@ func List(client *occlient.Client) ([]config.ApplicationInfo, error) {
 func Delete(client *occlient.Client, name string) error {
 	log.Debug("Deleting application %s", name)
 
-	labels, err := GetLabels(name, false)
-	if err != nil {
-		return errors.Wrapf(err, "unable to delete application %s", name)
-	}
+	labels := GetLabels(name, false)
 
 	// delete application from cluster
 	output, err := client.Delete("all", "", labels)

--- a/pkg/component/component.go
+++ b/pkg/component/component.go
@@ -33,14 +33,10 @@ type ComponentInfo struct {
 // additional labels are used only for creating object
 // if you are creating something use additional=true
 // if you need labels to filter component that use additional=false
-func GetLabels(componentName string, applicationName string, additional bool) (map[string]string, error) {
-	labels, err := application.GetLabels(applicationName, additional)
-	if err != nil {
-		return nil, errors.Wrapf(err, "unable to get get labels for  component %s", componentName)
-	}
+func GetLabels(componentName string, applicationName string, additional bool) map[string]string {
+	labels := application.GetLabels(applicationName, additional)
 	labels[ComponentLabel] = componentName
-
-	return labels, nil
+	return labels
 }
 
 func CreateFromGit(client *occlient.Client, name string, ctype string, url string) (string, error) {
@@ -62,11 +58,7 @@ func CreateFromGit(client *occlient.Client, name string, ctype string, url strin
 		}
 	}
 
-	labels, err := GetLabels(name, currentApplication, true)
-	if err != nil {
-		return "", errors.Wrapf(err, "unable to create git component %s", name)
-	}
-
+	labels := GetLabels(name, currentApplication, true)
 	// save component type as label
 	labels[componentTypeLabel] = ctype
 
@@ -98,11 +90,7 @@ func CreateFromDir(client *occlient.Client, name string, ctype string, dir strin
 		}
 	}
 
-	labels, err := GetLabels(name, currentApplication, true)
-	if err != nil {
-		return "", errors.Wrapf(err, "unable to create component %s from local path", name, dir)
-	}
-
+	labels := GetLabels(name, currentApplication, true)
 	// save component type as label
 	labels[componentTypeLabel] = ctype
 
@@ -141,10 +129,7 @@ func Delete(client *occlient.Client, name string) (string, error) {
 		return "", errors.Wrapf(err, "unable to delete component %s", name)
 	}
 
-	labels, err := GetLabels(name, currentApplication, false)
-	if err != nil {
-		return "", errors.Wrapf(err, "unable to delete component %s", name)
-	}
+	labels := GetLabels(name, currentApplication, false)
 
 	output, err := client.Delete("all", "", labels)
 	if err != nil {

--- a/pkg/url/url.go
+++ b/pkg/url/url.go
@@ -28,10 +28,7 @@ func Create(client *occlient.Client, cmp string) (*URL, error) {
 		return nil, errors.Wrap(err, "unable to get current application")
 	}
 
-	labels, err := component.GetLabels(cmp, app, false)
-	if err != nil {
-		return nil, errors.Wrap(err, "unable to get labels")
-	}
+	labels := component.GetLabels(cmp, app, false)
 
 	route, err := client.CreateRoute(cmp, labels)
 	if err != nil {


### PR DESCRIPTION
This commit removes the extra return value of type error from the
GetLabels() function in package application and package component.

There was no case under which these functions could have failed,
and having the error as a return was not required.