### PR TITLE
Add a bit of verbosity to e2e tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ test:
 # Run e2e tests
 .PHONY: test-e2e
 test-e2e:
-	go test github.com/redhat-developer/ocdev/tests/e2e
+	go test github.com/redhat-developer/ocdev/tests/e2e -ginkgo.v
 
 # create deb and rpm packages using fpm in ./dist/pkgs/
 # run make cross before this!

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -40,7 +40,7 @@ func runCmd(cmdS string) string {
 		os.Exit(1)
 	}
 
-	fmt.Println(string(out.Bytes()))
+	fmt.Printf("$ %s\n%s\n\n", cmdS, string(out.Bytes()))
 	return string(out.Bytes())
 }
 
@@ -123,7 +123,8 @@ var _ = Describe("Usecase #5", func() {
 		})
 	})
 
-	Context("creating an application", func() {
+	Describe("creating an application", func() {
+
 		Context("when application by the same name doesn't exist", func() {
 			It("should create an application", func() {
 				createApp("usecase5")


### PR DESCRIPTION
Adds verbosity to the tests as well as command-line-outout:

```sh
▶ make test-e2e
go test github.com/redhat-developer/ocdev/tests/e2e -ginkgo.v
$ git clone https://github.com/openshift/nodejs-ex /tmp/ocdev807324634/nodejs-ex

Running Suite: ocdev test suite
===============================
Random Seed: 1522871416
Will run 9 of 9 specs

Usecase #5 ocdev project
  should create a new project
  /home/wikus/seafile/files/dev/go/src/github.com/redhat-developer/ocdev/tests/e2e/e2e_test.go:120
$ ocdev project create ocdev-1522871416
New project created and now using project : ocdev-1522871416

$ ocdev project get --short
ocdev-1522871416

•
------------------------------
Usecase #5 creating an application when application by the same name doesn't exist
  should create an application
  /home/wikus/seafile/files/dev/go/src/github.com/redhat-developer/ocdev/tests/e2e/e2e_test.go:129
$ ocdev application create usecase5
Creating application: usecase5
Switched to application: usecase5

$ ocdev application get --short
usecase5

•
------------------------------
Usecase #5 creating an application when application by the same name doesn't exist
  should be created within the project
  /home/wikus/seafile/files/dev/go/src/github.com/redhat-developer/ocdev/tests/e2e/e2e_test.go:134
$ ocdev project get --short
ocdev-1522871416

```