### PR TITLE
Refactor cobra / use cobra.Args arguments

### DIFF
--- a/cmd/application.go
+++ b/cmd/application.go
@@ -27,15 +27,7 @@ var applicationCmd = &cobra.Command{
 var applicationCreateCmd = &cobra.Command{
 	Use:   "create",
 	Short: "create an application",
-	Args: func(cmd *cobra.Command, args []string) error {
-		if len(args) < 1 {
-			return fmt.Errorf("Please provide name for the new application")
-		}
-		if len(args) > 1 {
-			return fmt.Errorf("Only one argument (application name) is allowed")
-		}
-		return nil
-	},
+	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		// Args validation makes sure that there is exactly one argument
 		name := args[0]

--- a/cmd/component.go
+++ b/cmd/component.go
@@ -56,15 +56,8 @@ var componentSetCmd = &cobra.Command{
 	Example: `  # Set component named 'frontend' as active
   ocdev set component frontend
   `,
-	Args: func(cmd *cobra.Command, args []string) error {
-		if len(args) < 1 {
-			return fmt.Errorf("Please provide component name")
-		}
-		if len(args) > 1 {
-			return fmt.Errorf("Only one argument (component name) is allowed")
-		}
-		return nil
-	}, Run: func(cmd *cobra.Command, args []string) {
+	Args: cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
 		client := getOcClient()
 		err := component.SetCurrent(client, args[0])
 		if err != nil {

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -32,17 +32,7 @@ If component name is not provided, component type value will be used for name.
   # Create new nodejs component with source from remote git repository.
   ocdev create nodejs --git https://github.com/openshift/nodejs-ex.git
 	`,
-	Args: func(cmd *cobra.Command, args []string) error {
-		if len(args) < 1 {
-			// TODO: improve this message. It should say something about requiring component name
-			return fmt.Errorf("At least one argument is required")
-		}
-		if len(args) > 2 {
-			// TODO: Improve this message
-			return fmt.Errorf("Invalid arguments, maximum 2 arguments possible")
-		}
-		return nil
-	},
+	Args: cobra.RangeArgs(1, 2),
 	Run: func(cmd *cobra.Command, args []string) {
 		log.Debugf("Component create called with args: %#v, flags: binary=%s, git=%s, local=%s", strings.Join(args, " "), componentBinary, componentGit, componentLocal)
 

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -23,12 +23,7 @@ var componentDeleteCmd = &cobra.Command{
 	Example: `  # Delete component named 'frontend'. 
   ocdev delete frontend
 	`,
-	Args: func(cmd *cobra.Command, args []string) error {
-		if len(args) != 1 {
-			return fmt.Errorf("Please specify component name to delete.")
-		}
-		return nil
-	},
+	Args: cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		log.Debugf("component delete called")
 		log.Debugf("args: %#v", strings.Join(args, " "))

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -9,14 +9,8 @@ import (
 )
 
 var updateCmd = &cobra.Command{
-	Use: "update",
-	Args: func(cmd *cobra.Command, args []string) error {
-		if len(args) >= 2 {
-			// TODO: Improve this message
-			return fmt.Errorf("Invalid arguments, maximum 1 arguments possible")
-		}
-		return nil
-	},
+	Use:  "update",
+	Args: cobra.MaximumNArgs(1),
 	Example: `  # Change the source of a currently active component to local (use the current directory as a source)
   ocdev update --local
 


### PR DESCRIPTION
Uses the cobra.Args arguments for setting maximum / range / minimum
arguments required for some commands rather than using a custom checker.