### PR TITLE
Set application as default if current absent

### DIFF
--- a/pkg/application/application.go
+++ b/pkg/application/application.go
@@ -162,16 +162,22 @@ func GetCurrent(client *occlient.Client) (string, error) {
 	return app, nil
 }
 
-// GetCurrentOrDefault returns currently active application.
-// If no application is active returns defaultApplication name
-func GetCurrentOrDefault(client *occlient.Client) (string, error) {
+// GetCurrentOrGetAndSetDefault returns currently active application.
+// If no application is active returns defaultApplication name and sets it as
+// default as well
+func GetCurrentOrGetAndSetDefault(client *occlient.Client) (string, error) {
 	currentApp, err := GetCurrent(client)
 	if err != nil {
 		return "", errors.Wrap(err, "unable to get active application")
 	}
 	// if no Application is active use default
 	if currentApp == "" {
+		// get default application name
 		currentApp = getDefaultAppName()
+		// set default application as the current application
+		if err := SetCurrent(client, currentApp); err != nil {
+			return "", errors.Wrapf(err, "unable to set %v as the current application", currentApp)
+		}
 	}
 	return currentApp, nil
 }

--- a/pkg/component/component.go
+++ b/pkg/component/component.go
@@ -44,7 +44,7 @@ func CreateFromGit(client *occlient.Client, name string, ctype string, url strin
 	// if current application doesn't exist, create it
 	// this can happen when ocdev is started form clean state
 	// and default application is used (first command run is ocdev create)
-	currentApplication, err := application.GetCurrentOrDefault(client)
+	currentApplication, err := application.GetCurrentOrGetAndSetDefault(client)
 	if err != nil {
 		return errors.Wrapf(err, "unable to create git component %s", name)
 	}
@@ -88,7 +88,7 @@ func CreateFromGit(client *occlient.Client, name string, ctype string, url strin
 
 // CreateFromDir create new component with source from local directory
 func CreateFromDir(client *occlient.Client, name string, ctype string, dir string) error {
-	currentApplication, err := application.GetCurrentOrDefault(client)
+	currentApplication, err := application.GetCurrentOrGetAndSetDefault(client)
 	if err != nil {
 		return errors.Wrapf(err, "unable to create component %s from local path", name, dir)
 	}
@@ -129,7 +129,7 @@ func CreateFromDir(client *occlient.Client, name string, ctype string, dir strin
 
 // Delete whole component
 func Delete(client *occlient.Client, name string) (string, error) {
-	currentApplication, err := application.GetCurrentOrDefault(client)
+	currentApplication, err := application.GetCurrentOrGetAndSetDefault(client)
 	if err != nil {
 		return "", errors.Wrapf(err, "unable to delete component %s", name)
 	}
@@ -184,7 +184,7 @@ func GetCurrent(client *occlient.Client) (string, error) {
 	if err != nil {
 		return "", errors.Wrap(err, "unable to get config")
 	}
-	currentApplication, err := application.GetCurrentOrDefault(client)
+	currentApplication, err := application.GetCurrentOrGetAndSetDefault(client)
 	if err != nil {
 		return "", errors.Wrap(err, "unable to get active application")
 	}

--- a/pkg/url/url.go
+++ b/pkg/url/url.go
@@ -23,7 +23,7 @@ func Delete(client *occlient.Client, name string) error {
 // Create creates a URL
 func Create(client *occlient.Client, cmp string) (*URL, error) {
 
-	app, err := application.GetCurrentOrDefault(client)
+	app, err := application.GetCurrentOrGetAndSetDefault(client)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to get current application")
 	}


### PR DESCRIPTION
This commit refactors the GetCurrentOrDefault() function to
GetCurrentOrGetAndSetDefault(), because every caller expects the
default application to be set to default.