### PR TITLE
Rename storage add to storage create

### DIFF
--- a/cmd/storage.go
+++ b/cmd/storage.go
@@ -31,8 +31,8 @@ var storageCmd = &cobra.Command{
 	Long:  "Perform storage operations",
 }
 
-var storageAddCmd = &cobra.Command{
-	Use:   "add",
+var storageCreateCmd = &cobra.Command{
+	Use:   "create",
 	Short: "create storage and mount to component",
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
@@ -40,7 +40,7 @@ var storageAddCmd = &cobra.Command{
 		cmpnt := getComponent(client)
 		app, err := application.GetCurrent(client)
 		checkError(err, "")
-		_, err = storage.Add(client, args[0], storageSize, storagePath, cmpnt, app)
+		_, err = storage.Create(client, args[0], storageSize, storagePath, cmpnt, app)
 		checkError(err, "")
 		fmt.Printf("Added storage %v to %v\n", args[0], cmpnt)
 	},
@@ -99,12 +99,12 @@ var storageListCmd = &cobra.Command{
 }
 
 func init() {
-	storageAddCmd.Flags().StringVar(&storageSize, "size", "", "Size of storage to add")
-	storageAddCmd.MarkFlagRequired("size")
-	storageAddCmd.Flags().StringVar(&storagePath, "path", "", "Path to mount the storage on")
-	storageAddCmd.MarkFlagRequired("path")
+	storageCreateCmd.Flags().StringVar(&storageSize, "size", "", "Size of storage to add")
+	storageCreateCmd.MarkFlagRequired("size")
+	storageCreateCmd.Flags().StringVar(&storagePath, "path", "", "Path to mount the storage on")
+	storageCreateCmd.MarkFlagRequired("path")
 
-	storageCmd.AddCommand(storageAddCmd)
+	storageCmd.AddCommand(storageCreateCmd)
 	storageCmd.AddCommand(storageRemoveCmd)
 	storageCmd.AddCommand(storageListCmd)
 

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -18,8 +18,8 @@ type StorageInfo struct {
 	Path string
 }
 
-// Add adds storage to given component of given application
-func Add(client *occlient.Client, name string, size string, path string, componentName string, applicationName string) (string, error) {
+// Create adds storage to given component of given application
+func Create(client *occlient.Client, name string, size string, path string, componentName string, applicationName string) (string, error) {
 
 	labels := GetLabels(name, componentName, applicationName, true)
 

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -237,7 +237,7 @@ var _ = Describe("ocdev", func() {
 	Describe("Adding storage", func() {
 		Context("when storage is added", func() {
 			It("should default to active component when no component name is passed", func() {
-				storAdd := runCmd("ocdev storage add pv1 --path /mnt/pv1 --size 5Gi")
+				storAdd := runCmd("ocdev storage create pv1 --path /mnt/pv1 --size 5Gi")
 				Expect(storAdd).To(ContainSubstring("nodejs"))
 
 				// Check against path and name against dc
@@ -269,7 +269,7 @@ var _ = Describe("ocdev", func() {
 			})
 
 			It("should be able add storage to a component specified", func() {
-				runCmd("ocdev storage add pv2 --path /mnt/pv2 --size 5Gi --component php")
+				runCmd("ocdev storage create pv2 --path /mnt/pv2 --size 5Gi --component php")
 
 				storList := runCmd("ocdev storage list --component php")
 				Expect(storList).To(ContainSubstring("pv2"))


### PR DESCRIPTION
This commit renames the `ocdev storage add` command to `ocdev
storage create` command as per the original use case requirements